### PR TITLE
Remove plot loading by default

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,4 +5,3 @@ RecipesBase 0.5.0
 SpecialFunctions 0.7.0
 Distributions 0.16.2
 AxisArrays 0.3.0
-Requires 0.5.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ RecipesBase 0.5.0
 SpecialFunctions 0.7.0
 Distributions 0.16.2
 AxisArrays 0.3.0
+Requires 0.5.2

--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -8,7 +8,9 @@ import Serialization: serialize, deserialize
 import Base: sort, range, names
 import Statistics: cor
 
-using Requires
+using RecipesBase
+import RecipesBase: plot
+
 using Serialization
 using Distributions
 using SpecialFunctions
@@ -53,9 +55,6 @@ include("heideldiag.jl")
 include("mcse.jl")
 include("rafterydiag.jl")
 include("stats.jl")
-
-function __init__()
-    @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" @eval include("plot.jl")
-end
+include("plot.jl")
 
 end # module

--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -8,9 +8,7 @@ import Serialization: serialize, deserialize
 import Base: sort, range, names
 import Statistics: cor
 
-using RecipesBase
-import RecipesBase: plot
-
+using Requires
 using Serialization
 using Distributions
 using SpecialFunctions
@@ -18,7 +16,6 @@ using AxisArrays
 const axes = Base.axes
 
 export Chains, getindex, setindex!, chains
-export plot, traceplot, meanplot, densityplot, histogramplot, mixeddensityplot, autcorplot
 export describe
 
 # export diagnostics functions
@@ -54,11 +51,11 @@ include("gelmandiag.jl")
 include("gewekediag.jl")
 include("heideldiag.jl")
 include("mcse.jl")
-#include("modelchains.jl")
-#include("modelstats.jl")
 include("rafterydiag.jl")
 include("stats.jl")
-include("plot.jl")
-#include("plot2.jl")
+
+function __init__()
+    @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" @eval include("plot.jl")
+end
 
 end # module

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,14 +1,3 @@
-using RecipesBase
-import RecipesBase: plot
-
-export plot,
-    traceplot,
-    meanplot,
-    densityplot,
-    histogramplot,
-    mixeddensityplot,
-    autcorplot
-
 @shorthands meanplot
 @shorthands autocorplot
 @shorthands mixeddensity

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -1,3 +1,13 @@
+using RecipesBase
+import RecipesBase: plot
+
+export plot,
+    traceplot,
+    meanplot,
+    densityplot,
+    histogramplot,
+    mixeddensityplot,
+    autcorplot
 
 @shorthands meanplot
 @shorthands autocorplot


### PR DESCRIPTION
See #37. MCMCChains will now only export (and load) `plot` if `Plots` or `StatsPlots` is loaded first. Anyone see any obvious issues with this implementation?