### PR TITLE
Added NamedTuple functionality to Chains objects

### DIFF
--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -17,7 +17,7 @@ using SpecialFunctions
 using AxisArrays
 const axes = Base.axes
 
-export Chains, getindex, setindex!, chains
+export Chains, getindex, setindex!, chains, setinfo
 export describe
 
 # export diagnostics functions
@@ -30,16 +30,17 @@ abstract type AbstractChains end
 
 Parameters:
 
-- `value`: `iterations × variables × chains` Data array
-- `range`: Range describing the iterations (considering thinning)
-- `names`: List of variable names (strings)
-- `chains`: List of chain ids
+- `value`: An `AxisArray` object with axes `iter` × `var` × `chains`
+- `logevidence` : A field containing the logevidence.
+- `name_map` : A `NamedTuple` mapping each variable to a section.
+- `info` : A `NamedTuple` containing miscellaneous information relevant to the chain.
+The `info` field can be set using `setinfo(c::Chains, n::NamedTuple)`.
 """
-struct Chains{A, T} <: AbstractChains
+struct Chains{A, T, K<:NamedTuple, L<:NamedTuple} <: AbstractChains
     value::AxisArray{Union{Missing,A},3}
     logevidence::T
-    name_map::Dict{Any, Vector}
-    info::Dict{Symbol, Any}
+    name_map::K
+    info::L
 end
 
 # imports
@@ -53,8 +54,11 @@ include("gelmandiag.jl")
 include("gewekediag.jl")
 include("heideldiag.jl")
 include("mcse.jl")
+#include("modelchains.jl")
+#include("modelstats.jl")
 include("rafterydiag.jl")
 include("stats.jl")
 include("plot.jl")
+#include("plot2.jl")
 
 end # module

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -52,3 +52,13 @@ function natural(x, y)
     end
     return length(xarr) < length(yarr)
 end
+
+function _dict2namedtuple(d::Dict)
+    t_keys = ntuple(x -> Symbol(collect(keys(d))[x]), length(keys(d)))
+    t_vals = ntuple(x -> collect(values(d))[x], length(values(d)))
+    return NamedTuple{t_keys}(t_vals)
+end
+
+function _namedtuple2dict(n::NamedTuple)
+    return Dict(pairs(n))
+end

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -25,6 +25,7 @@ chn = Chains(val, start = 1, thin = 2)
     @test all(collect(skipmissing(chn[:,1,1].value)) .== val[:,1,1])
     @test all(chn[:,1,2].value .== val[:,1,2])
     @test all(MCMCChains.indiscretesupport(chn) .== [false, false, false, true])
+    @test setinfo(chn, NamedTuple{(:A, :B)}((1,2))).info == NamedTuple{(:A, :B)}((1,2))
 end
 
 @testset "function tests" begin


### PR DESCRIPTION
This PR changes the definition of a `Chains` object to 

```julia
struct Chains{A, T, K<:NamedTuple, L<:NamedTuple} <: AbstractChains
    value::AxisArray{Union{Missing,A},3}
    logevidence::T
    name_map::K
    info::L
end
```

Previously, `name_map` and `info` were of type `Dict`. This makes `Chains` object significantly more type stable. A new external function `setinfo(c::Chains, n::NamedTuple)` was added, which returns a new chain with `n` stored in `c.info`.

Additionally, I added some docstrings and did a little bit of tidying up.

@goedman do you see any conflicts here with anything on your end?