### PR TITLE
Improve concatenation, improve default show function.

### DIFF
--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -17,7 +17,7 @@ using SpecialFunctions
 using AxisArrays
 const axes = Base.axes
 
-export Chains, getindex, setindex!, chains, setinfo
+export Chains, getindex, setindex!, chains, setinfo, chainscat
 export describe
 
 # export diagnostics functions

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -27,6 +27,8 @@ function Chains(val::AbstractArray{A,3},
     # If we received an array of pairs, convert it to a dictionary.
     if typeof(name_map) <: Array
         name_map = Dict(name_map)
+    elseif typeof(name_map) <: NamedTuple
+        name_map = _namedtuple2dict(name_map)
     end
 
     # Make sure that we have a :parameters index.
@@ -79,6 +81,12 @@ function Chains(val::AbstractArray{A,3},
 
     # Make the name_map NamedTuple.
     name_map_tupl = _dict2namedtuple(name_map)
+
+    # Ensure that we have a hashedsummary key in info.
+    if !in(:hashedsummary, keys(info))
+        s = (hash(0), ChainSummaries("", []))
+        info = merge(info, (hashedsummary = Ref(s),))
+    end
 
     # Construct the AxisArray.
     axs = ntuple(i -> Axis{names[i]}(axvals[i]), 3)
@@ -178,100 +186,37 @@ end
 
 Base.setindex!(c::Chains, v, i...) = setindex!(c.value, v, i...)
 
-#################### Concatenation ####################
-
-function Base.cat(dim::Integer, c1::AbstractChains, args::AbstractChains...)
-  dim == 1 ? cat1(c1, args...) :
-  dim == 2 ? cat2(c1, args...) :
-  dim == 3 ? cat3(c1, args...) :
-    throw(ArgumentError("cannot concatenate along dimension $dim"))
-end
-
-function cat1(c1::AbstractChains, args::AbstractChains...)
-  range = c1.range
-  for c in args
-    last(range) + step(range) == first(c) ||
-      throw(ArgumentError("noncontiguous chain iterations"))
-    step(range) == step(c) ||
-      throw(ArgumentError("chain thinning differs"))
-    range = first(range):step(range):last(c)
-  end
-
-  names = c1.names
-  all(c -> c.names == names, args) ||
-    throw(ArgumentError("chain names differ"))
-
-  chains = c1.chains
-  all(c -> c.chains == chains, args) ||
-    throw(ArgumentError("sets of chains differ"))
-
-  value = cat(1, c1.value, map(c -> c.value, args)...)
-  Chains(value, start=first(range), thin=step(range), names=names,
-         chains=chains)
-end
-
-function cat2(c1::AbstractChains, args::AbstractChains...)
-  range = c1.range
-  all(c -> c.range == range, args) ||
-    throw(ArgumentError("chain ranges differ"))
-
-  names = c1.names
-  n = length(names)
-  for c in args
-    names = union(names, c.names)
-    n += length(c.names)
-    n == length(names) ||
-      throw(ArgumentError("non-unique chain names"))
-  end
-
-  chains = c1.chains
-  all(c -> c.chains == chains, args) ||
-    throw(ArgumentError("sets of chains differ"))
-
-  value = cat(2, c1.value, map(c -> c.value, args)...)
-  Chains(value, start=first(range), thin=step(range), names=names,
-         chains=chains)
-end
-
-function cat3(c1::AbstractChains, args::AbstractChains...)
-  range = c1.range
-  all(c -> c.range == range, args) ||
-    throw(ArgumentError("chain ranges differ"))
-
-  names = c1.names
-  all(c -> c.names == names, args) ||
-    throw(ArgumentError("chain names differ"))
-
-  value = cat(3, c1.value, map(c -> c.value, args)...)
-  Chains(value, start=first(range), thin=step(range), names=names)
-end
-
-Base.hcat(c1::AbstractChains, args::AbstractChains...) = cat(2, c1, args...)
-
-Base.vcat(c1::AbstractChains, args::AbstractChains...) = cat(1, c1, args...)
-
 
 #################### Base Methods ####################
 
-function Base.keys(c::AbstractChains)
-    names(c)
-end
-
 function Base.show(io::IO, c::Chains)
-    print(io, "Object of type \"$(summary(c))\"\n\n")
+    print(io, "Object of type Chains, with data of type $(summary(c.value.data))\n\n")
     println(io, header(c))
-    # show(io, summarystats(c))
+
+    # Grab the value hash.
+    h = hash(c.value)
+
+    if :hashedsummary in keys(c.info)
+        s = c.info.hashedsummary.x
+        if s[1] == h
+            show(io, s[2])
+        else
+            new_summary = summarystats(c, suppress_header=true)
+            c.info.hashedsummary.x = (h, new_summary)
+            show(io, new_summary)
+        end
+    else
+        show(io, summarystats(c, suppress_header=true))
+    end
 end
 
 function Base.size(c::AbstractChains)
-    dim = size(c.value)
-    last(c), dim[2], dim[3]
+  dim = size(c.value)
+  last(c), dim[2], dim[3]
 end
 
-function Base.size(c::AbstractChains, ind)
-    size(c)[ind]
-end
-
+Base.keys(c::AbstractChains) = names(c)
+Base.size(c::AbstractChains, ind) = size(c)[ind]
 Base.length(c::AbstractChains) = length(range(c))
 Base.first(c::AbstractChains) = first(c.value[Axis{:iter}].val)
 Base.step(c::AbstractChains) = step(c.value[Axis{:iter}].val)
@@ -297,7 +242,7 @@ end
 
 Returns the range used in a `Chains` object.
 """
-function Base.range(c::AbstractChains)
+function range(c::AbstractChains)
     return c.value[Axis{:iter}].val
 end
 
@@ -315,7 +260,7 @@ end
 
 Return the parameter names in a `Chains` object.
 """
-function Base.names(c::AbstractChains)
+function names(c::AbstractChains)
     return c.value[Axis{:var}].val
 end
 
@@ -473,4 +418,116 @@ function setinfo(c::Chains{A, T, K}, n::NamedTuple) where {A, T, K}
         c.name_map,
         n
     )
+end
+
+
+#################### Concatenation ####################
+
+function Base.cat(c1::AbstractChains, args::AbstractChains...; dims::Integer = 3)
+  dims == 1 ? cat1(c1, args...) :
+  dims == 2 ? cat2(c1, args...) :
+  dims == 3 ? cat3(c1, args...) :
+    throw(ArgumentError("cannot concatenate along dimension $dim"))
+end
+
+function cat1(c1::AbstractChains, args::AbstractChains...)
+    rng = range(c1)
+    for c in args
+        last(rng) + step(rng) == first(c) ||
+            throw(ArgumentError("noncontiguous chain iterations"))
+        step(rng) == step(c) ||
+            throw(ArgumentError("chain thinning differs"))
+        rng = first(rng):step(rng):last(c)
+    end
+
+    nms = names(c1)
+    all(c -> names(c) == nms, args) ||
+        throw(ArgumentError("chain names differ"))
+
+    chns = chains(c1)
+    all(c -> chains(c1) == chns, args) ||
+        throw(ArgumentError("sets of chains differ"))
+
+    name_map = _ntdictmerge(c1.name_map, map(c -> c.name_map, args)...)
+
+    value = cat(c1.value, map(c -> c.value, args)..., dims=1)
+    Chains(value, nms, name_map, start=first(rng), thin=step(rng),
+        info = c1.info)
+end
+
+function cat2(c1::AbstractChains, args::AbstractChains...)
+  rng = range(c1)
+  all(c -> range(c) == rng, args) ||
+    throw(ArgumentError("chain ranges differ"))
+
+  nms = names(c1)
+  n = length(nms)
+  for c in args
+    nms = union(nms, names(c))
+    n += length(names(c))
+    n == length(nms) ||
+      throw(ArgumentError("non-unique parameter names"))
+  end
+
+  name_map = _ntdictmerge(c1.name_map, map(c -> c.name_map, args)...)
+
+  chns = chains(c1)
+  all(c -> chains(c) == chns, args) ||
+    throw(ArgumentError("sets of chains differ"))
+
+  value = cat(c1.value, map(c -> c.value, args)..., dims=2)
+  Chains(value, nms, name_map, start=first(rng), thin=step(rng),
+      info = c1.info)
+end
+
+function cat3(c1::AbstractChains, args::AbstractChains...)
+  rng = range(c1)
+  all(c -> range(c) == rng, args) ||
+    throw(ArgumentError("chain ranges differ"))
+
+  nms = names(c1)
+
+  name_map = _ntdictmerge(c1.name_map, map(c -> c.name_map, args)...)
+
+  value = cat(c1.value.data, map(c -> c.value.data, args)..., dims=3)
+  Chains(value, nms, name_map, start=first(rng), thin=step(rng),
+      info = c1.info)
+end
+
+Base.hcat(c1::AbstractChains, args::AbstractChains...) = cat(2, c1, args...)
+# Base.vcat(c1::AbstractChains, args::AbstractChains...) = cat(1, c1, args...)
+
+function Base.vcat(cs::Chains...)
+    c1 = cs[1]
+
+    evidence = c1.logevidence
+    nms = names(c1)
+    rng = range(c1)
+    chns = chains(c1)
+
+    value = c1.value
+    info = c1.info
+    name_map = c1.name_map
+
+    all(c -> names(c) == nms, cs) ||
+        throw(ArgumentError("parameter names differ"))
+
+    all(c -> chains(c) == chns, cs) ||
+        throw(ArgumentError("sets of chains differ"))
+
+    for c in cs[2:end]
+        @assert evidence == c.logevidence
+        @assert rng == range(c)
+
+        value = cat(value, c.value, dims=1)
+        info = _ntdictmerge(info, map(c -> c.info, args)...)
+        name_map = _ntdictmerge(name_map, map(c -> c.name_map, args)...)
+    end
+
+    chn = Chains(value,
+                nms,
+                name_map,
+                info=info,
+                evidence=evidence)
+    return chn
 end

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -494,40 +494,6 @@ function cat3(c1::AbstractChains, args::AbstractChains...)
       info = c1.info)
 end
 
-Base.hcat(c1::AbstractChains, args::AbstractChains...) = cat(2, c1, args...)
-# Base.vcat(c1::AbstractChains, args::AbstractChains...) = cat(1, c1, args...)
-
-function Base.vcat(cs::Chains...)
-    c1 = cs[1]
-
-    evidence = c1.logevidence
-    nms = names(c1)
-    rng = range(c1)
-    chns = chains(c1)
-
-    value = c1.value
-    info = c1.info
-    name_map = c1.name_map
-
-    all(c -> names(c) == nms, cs) ||
-        throw(ArgumentError("parameter names differ"))
-
-    all(c -> chains(c) == chns, cs) ||
-        throw(ArgumentError("sets of chains differ"))
-
-    for c in cs[2:end]
-        @assert evidence == c.logevidence
-        @assert rng == range(c)
-
-        value = cat(value, c.value, dims=1)
-        info = _ntdictmerge(info, map(c -> c.info, args)...)
-        name_map = _ntdictmerge(name_map, map(c -> c.name_map, args)...)
-    end
-
-    chn = Chains(value,
-                nms,
-                name_map,
-                info=info,
-                evidence=evidence)
-    return chn
-end
+chainscat(c1::AbstractChains, args::AbstractChains...) = cat(c1, args..., dims=3)
+Base.hcat(c1::AbstractChains, args::AbstractChains...) = cat(c1, args..., dims=2)
+Base.vcat(c1::AbstractChains, args::AbstractChains...) = cat(c1, args..., dims=1)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -62,3 +62,9 @@ end
 function _namedtuple2dict(n::NamedTuple)
     return Dict(pairs(n))
 end
+
+function _ntdictmerge(n::NamedTuple, args::NamedTuple...)
+    ndict = _namedtuple2dict(n)
+    ndict2 = map(x -> _namedtuple2dict(x), args)
+    return _dict2namedtuple(merge(ndict, ndict2...))
+end

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -63,6 +63,7 @@ end
     @test range(c1_2) == 1:1:1000
     @test names(c1_2) == names(c1) == names(c2)
     @test chains(c1_2) == chains(c1) == chains(c2)
+    @test c1_2.value == vcat(c1, c2).value
 
     # Test dim 2
     c1_3 = cat(c1, c3, dims = 2)
@@ -70,6 +71,7 @@ end
     @test range(c1_3) == 1:1:500
     @test names(c1_3) == cat(names(c1), names(c3), dims=1)
     @test chains(c1_3) == chains(c1) == chains(c3)
+    @test c1_3.value == hcat(c1, c3).value
 
     # Test dim 3
     c1_4 = cat(c1, c4, dims = 3)
@@ -77,4 +79,5 @@ end
     @test range(c1_4) == 1:1:500
     @test names(c1_4) == names(c1) == names(c4)
     @test length(chains(c1_4)) == length(chains(c1)) + length(chains(c4))
+    @test c1_4.value == chainscat(c1, c4).value
 end

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -45,3 +45,36 @@ end
     @test isa(heideldiag(chn[:,1,:]), MCMCChains.ChainSummary)
     @test isa(rafterydiag(chn[:,1,:]), MCMCChains.ChainSummary)
 end
+
+@testset "concatenation tests" begin
+    v1 = rand(500, 5, 1)
+    v2 = rand(500, 5, 1)
+    v3 = rand(500, 4, 1)
+    v4 = rand(500, 5, 4)
+
+    c1 = Chains(v1, [:a1, :a2, :a3, :a4, :a5])
+    c2 = Chains(v2, [:a1, :a2, :a3, :a4, :a5], start = 501)
+    c3 = Chains(v3, [:z1, :z2, :z3, :z4])
+    c4 = Chains(v4, [:a1, :a2, :a3, :a4, :a5])
+
+    # Test dim 1
+    c1_2 = cat(c1, c2, dims = 1)
+    @test c1_2.value.data == cat(v1, v2, dims=1)
+    @test range(c1_2) == 1:1:1000
+    @test names(c1_2) == names(c1) == names(c2)
+    @test chains(c1_2) == chains(c1) == chains(c2)
+
+    # Test dim 2
+    c1_3 = cat(c1, c3, dims = 2)
+    @test c1_3.value.data == cat(v1, v3, dims=2)
+    @test range(c1_3) == 1:1:500
+    @test names(c1_3) == cat(names(c1), names(c3), dims=1)
+    @test chains(c1_3) == chains(c1) == chains(c3)
+
+    # Test dim 3
+    c1_4 = cat(c1, c4, dims = 3)
+    @test c1_4.value.data == cat(v1, v4, dims=3)
+    @test range(c1_4) == 1:1:500
+    @test names(c1_4) == names(c1) == names(c4)
+    @test length(chains(c1_4)) == length(chains(c1)) + length(chains(c4))
+end


### PR DESCRIPTION
Addresses #28 and #43, and fixes broken concatenation functions. `Chains` objects now store references to `ChainSummaries`, so the math doesn't have to be redone every time `show` is called. I have also added a `chainscat` function, which adds separate chains together. This is to make it a bit easier to add separate chains together (at least on the Turing side):

```julia
chains = mapreduce(c -> sample(model, sampler), chainscat, 1:num_chains)
```

The default `show` function now prints out:

```
Object of type Chains, with data of type 500×5×3 Array{Union{Missing, Float64},3}

Iterations        = 1:500
Thinning interval = 1
Chains            = Chain1, Chain2, Chain3
Samples per chain = 500
internals         = a35
parameters        = a, a11, a2, a21

parameters
     Mean    SD   Naive SE  MCSE  ESS
  a 0.5002 0.2876   0.0074 0.0063 500
 a2 0.4995 0.2909   0.0075 0.0068 500
a11 0.4988 0.2845   0.0073 0.0077 500
a21 0.4892 0.2948   0.0076 0.0060 500
```

The above output is cached and is only recalculated if `hash(chn.value)` changes.