### PR TITLE
Updated serialization tests to use Turing

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Pkg
 to_add = [
     PackageSpec(name="Plots"),
     PackageSpec(name="StatsPlots"),
+    PackageSpec(name="Turing"),
 ]
 
 Pkg.add(to_add)

--- a/test/serialization_tests.jl
+++ b/test/serialization_tests.jl
@@ -1,10 +1,19 @@
-using  MCMCChains, Test
+using Turing, Test
 
 ProjDir = mktempdir()
 
 @testset "serialization read and write test" begin
-    val = rand(500, 5, 1)
-    chn1 = Chains(val)
+    @model gdemo(x) = begin
+        s ~ InverseGamma(2,3)
+        m ~ Normal(0, sqrt(s))
+        for i in eachindex(x)
+            x[i] ~ Normal(m, sqrt(s))
+        end
+    end
+
+    model = gdemo([1.5, 2.0])
+    sampler = HMC(500, 0.01, 5)
+    chn1 = sample(model, sampler, save_state=true)
 
     write(joinpath(ProjDir, "chn1.jls"), chn1)
     chn2 = read(joinpath(ProjDir, "chn1.jls"), MCMCChains.Chains)
@@ -19,6 +28,10 @@ ProjDir = mktempdir()
 
     @test open(f->read(f, String), joinpath(ProjDir, "chn1.txt")) ==
         open(f->read(f, String), joinpath(ProjDir, "chn2.txt"))
+
+    # Test whether sampler state made it through serialization/deserialization.
+    chn3 = Turing.Utilities.resume(chn2, 100)
+    @test range(chn3) == 1:1:600
 end
 
 rm(ProjDir, force=true, recursive=true)


### PR DESCRIPTION
Updates the serialization/deserialization tests to use a Turing model to make sure everything's kosher. This also tests to make sure that anything in the `Chains.info` field makes it through by trying to resume sampling from a deserialized chain. 