### PR TITLE
Support sections for diagnostic functions

### DIFF
--- a/src/chains.jl
+++ b/src/chains.jl
@@ -103,7 +103,13 @@ function Chains(c::Chains{A, T, K, L}, section::Union{Vector, Any};
     section = typeof(section) <: AbstractArray ? section : [section]
 
     # If we received an empty list, return the original chain.
-    if isempty(section) return c end
+    if isempty(section)
+        if sorted
+            return sort(new_chn)
+        else
+            return new_chn
+        end
+    end
 
     # Gather the names from the relevant sections.
     names = []

--- a/src/discretediag.jl
+++ b/src/discretediag.jl
@@ -416,10 +416,12 @@ end
 #  return [p1, p2]
 #end
 
-function discretediag(c::AbstractChains; frac::Real=0.3,
-                      method::Symbol=:weiss, nsim::Int=1000)
+function discretediag(chn::AbstractChains; frac::Real=0.3,
+                      method::Symbol=:weiss, section=:parameters,
+                      nsim::Int=1000, showall=false)
 
     @assert !any(ismissing.(c.value)) "Diagnostic doesn't support missing values"
+    c = showall ? sort(chn) : Chains(chn, section; sorted=true)
 
     num_iters, num_vars, num_chains = size(c.value)
 
@@ -441,8 +443,9 @@ function discretediag(c::AbstractChains; frac::Real=0.3,
     #println(V)
     #println(vals)
 
-    hdr = header(c) * "\nChisq Diagnostic:\nEnd Fractions = $frac\n" *
-    "method = $method\n"
+    section_name = showall ? "" : "\n" * string(section) * "\n"
+    hdr = "Chisq Diagnostic:\nEnd Fractions = $frac\n" *
+    "method = $method\n"  * section_name
 
     return ChainSummary(collect(round.(vals, digits = 3)'), string.(names(c))[V],
     convert(Array{AbstractString, 1},

--- a/src/discretediag.jl
+++ b/src/discretediag.jl
@@ -420,8 +420,8 @@ function discretediag(chn::AbstractChains; frac::Real=0.3,
                       method::Symbol=:weiss, section=:parameters,
                       nsim::Int=1000, showall=false)
 
-    @assert !any(ismissing.(c.value)) "Diagnostic doesn't support missing values"
     c = showall ? sort(chn) : Chains(chn, section; sorted=true)
+    @assert !any(ismissing.(c.value)) "Diagnostic doesn't support missing values"
 
     num_iters, num_vars, num_chains = size(c.value)
 

--- a/src/gelmandiag.jl
+++ b/src/gelmandiag.jl
@@ -1,63 +1,63 @@
 #################### Gelman, Rubin, and Brooks Diagnostics ####################
 
-function gelmandiag(c::AbstractChains; alpha::Real=0.05, mpsrf::Bool=false,
-                    transform::Bool=false)
-
+function gelmandiag(chn::AbstractChains; alpha::Real=0.05, mpsrf::Bool=false,
+                    transform::Bool=false, section = :parameters, showall=false)
+    c = showall ? sort(chn) : Chains(chn, section; sorted=true)
     @assert !any(ismissing.(c.value)) "Gelman diagnostics doesn't support missing values"
 
     n, p, m = size(c.value)
-  m >= 2 ||
+    m >= 2 ||
     throw(ArgumentError("less than 2 chains supplied to gelman diagnostic"))
 
-  psi = transform ? link(c) : c.value
+    psi = transform ? link(c) : c.value
 
-  S2 = mapslices(cov, psi, dims = [1, 2])
-  W = dropdims(mapslices(mean, S2, dims = [3]), dims = 3)
+    S2 = mapslices(cov, psi, dims = [1, 2])
+    W = dropdims(mapslices(mean, S2, dims = [3]), dims = 3)
 
-  psibar = reshape(mapslices(mean, convert(Array, psi), dims = [1]), p, m)'
-  B = n * cov(psibar)
+    psibar = reshape(mapslices(mean, convert(Array, psi), dims = [1]), p, m)'
+    B = n * cov(psibar)
 
-  w = diag(W)
-  b = diag(B)
-  s2 = reshape(mapslices(diag, S2, dims = [1, 2]), p, m)'
-  psibar2 = vec(mapslices(mean, psibar, dims = [1]))
+    w = diag(W)
+    b = diag(B)
+    s2 = reshape(mapslices(diag, S2, dims = [1, 2]), p, m)'
+    psibar2 = vec(mapslices(mean, psibar, dims = [1]))
 
-  var_w = vec(mapslices(var, s2, dims = [1])) / m
-  var_b = (2.0 / (m - 1)) * b.^2
-  var_wb = (n / m) * (diag(cov(s2, psibar.^2))
-                      - 2.0 * psibar2 .* diag(cov(s2, psibar)))
+    var_w = vec(mapslices(var, s2, dims = [1])) / m
+    var_b = (2.0 / (m - 1)) * b.^2
+    var_wb = (n / m) * (diag(cov(s2, psibar.^2))
+            - 2.0 * psibar2 .* diag(cov(s2, psibar)))
 
-  V = ((n - 1) / n) * w + ((m + 1) / (m * n)) * b
-  var_V = ((n - 1)^2 * var_w + ((m + 1) / m)^2 * var_b +
-           (2.0 * (n - 1) * (m + 1) / m) * var_wb) / n^2
-  df = 2.0 * V.^2 ./ var_V
-  B_df = m - 1
-  W_df = 2.0 * w.^2 ./ var_w
+    V = ((n - 1) / n) * w + ((m + 1) / (m * n)) * b
+    var_V = ((n - 1)^2 * var_w + ((m + 1) / m)^2 * var_b +
+        (2.0 * (n - 1) * (m + 1) / m) * var_wb) / n^2
+    df = 2.0 * V.^2 ./ var_V
+    B_df = m - 1
+    W_df = 2.0 * w.^2 ./ var_w
 
-  psrf = Array{Float64}(undef, p, 2)
-  R_fixed = (n - 1) / n
-  R_random_scale = (m + 1) / (m * n)
-  q = 1.0 - alpha / 2.0
-  for i in 1:p
-    correction = (df[i] + 3.0) / (df[i] + 1.0)
-    R_random = R_random_scale * b[i] / w[i]
-    psrf[i, 1] = sqrt(correction * (R_fixed + R_random))
-    if !isnan(R_random)
-      R_random *= quantile(FDist(B_df, W_df[i]), q)
+    psrf = Array{Float64}(undef, p, 2)
+    R_fixed = (n - 1) / n
+    R_random_scale = (m + 1) / (m * n)
+    q = 1.0 - alpha / 2.0
+    for i in 1:p
+        correction = (df[i] + 3.0) / (df[i] + 1.0)
+        R_random = R_random_scale * b[i] / w[i]
+        psrf[i, 1] = sqrt(correction * (R_fixed + R_random))
+        if !isnan(R_random)
+            R_random *= quantile(FDist(B_df, W_df[i]), q)
+        end
+        psrf[i, 2] = sqrt(correction * (R_fixed + R_random))
     end
-    psrf[i, 2] = sqrt(correction * (R_fixed + R_random))
-  end
-  psrf_labels = ["PSRF", string(100 * q) * "%"]
-  psrf_names = string.(names(c))
+    psrf_labels = ["PSRF", string(100 * q) * "%"]
+    psrf_names = string.(names(c))
 
-  if mpsrf
-    x = isposdef(W) ?
-      R_fixed + R_random_scale * eigmax(inv(cholfact(W)) * B) :
-      NaN
-    psrf = vcat(psrf, [x NaN])
-    psrf_names = [psrf_names; "Multivariate"]
-  end
+    if mpsrf
+        x = isposdef(W) ?
+        R_fixed + R_random_scale * eigmax(inv(cholfact(W)) * B) : NaN
+        psrf = vcat(psrf, [x NaN])
+        psrf_names = [psrf_names; "Multivariate"]
+    end
 
-  hdr = header(c) * "\nGelman, Rubin, and Brooks Diagnostic:"
-  ChainSummary(round.(psrf, digits = 3), psrf_names, psrf_labels, hdr, true)
+    section_name = showall ? "" : string(section) * "\n"
+    hdr = "Gelman, Rubin, and Brooks Diagnostic:\n" * section_name
+    ChainSummary(round.(psrf, digits = 3), psrf_names, psrf_labels, hdr, true)
 end

--- a/src/gewekediag.jl
+++ b/src/gewekediag.jl
@@ -17,8 +17,9 @@ function gewekediag(x::Vector{T}; first::Real=0.1, last::Real=0.5,
   [round(z, digits = 3), round(1.0 - erf(abs(z) / sqrt(2.0)), digits = 4)]
 end
 
-function gewekediag(c::AbstractChains; first::Real=0.1, last::Real=0.5,
-                    etype=:imse, args...)
+function gewekediag(chn::AbstractChains; first::Real=0.1, last::Real=0.5,
+                    etype=:imse, section=:parameters, showall=false, args...)
+    c = showall ? sort(chn) : Chains(chn, section; sorted=true)
 
     _, p, m = size(c.value)
     vals = Array{Float64}(undef, p, 2, m)
@@ -31,7 +32,9 @@ function gewekediag(c::AbstractChains; first::Real=0.1, last::Real=0.5,
                             args...
                         )
     end
-    hdr = header(c) * "\nGeweke Diagnostic:\nFirst Window Fraction = $first\n" *
-        "Second Window Fraction = $last\n"
+    section_name = showall ? "" : "\n" * string(section) * "\n"
+    hdr = "Geweke Diagnostic:\nFirst Window Fraction = $first\n" *
+        "Second Window Fraction = $last\n" *
+        section_name
     return ChainSummary(vals, string.(names(c)), ["Z-score", "p-value"], hdr, true)
 end

--- a/src/heideldiag.jl
+++ b/src/heideldiag.jl
@@ -26,15 +26,20 @@ function heideldiag(x::Vector{T}; alpha::Real=0.05, eps::Real=0.1,
   [i + start - 2, converged, round(pvalue, digits = 4), ybar, halfwidth, passed]
 end
 
-function heideldiag(c::AbstractChains;
+function heideldiag(chn::AbstractChains;
                     alpha = 0.05,
                     eps = 0.1,
                     etype = :imse,
+                    section = :parameters,
+                    showall=false,
                     args...
                    )
+    c = showall ? sort(chn) : Chains(chn, section; sorted=true)
+
     # Preallocate.
     _, p, m = size(c.value)
     vals = Array{Float64}(undef, p, 6, m)
+
 
     # Perform tests.
     for j in 1:p, k in 1:m
@@ -49,8 +54,9 @@ function heideldiag(c::AbstractChains;
     end
 
     # Set header.
-    hdr = header(c) * "\nHeidelberger and Welch Diagnostic:\n" *
-        "Target Halfwidth Ratio = $eps\nAlpha = $alpha\n"
+    section_name = showall ? "" : "\n" * string(section) * "\n"
+    hdr = "\nHeidelberger and Welch Diagnostic:\n" *
+        "Target Halfwidth Ratio = $eps\nAlpha = $alpha\n" * section_name
 
     # Round values.
     vals = map(x -> round(x, digits=4), vals)

--- a/src/rafterydiag.jl
+++ b/src/rafterydiag.jl
@@ -52,13 +52,16 @@ function rafterydiag(
 end
 
 function rafterydiag(
-                     c::AbstractChains;
+                     chn::AbstractChains;
                      q = 0.025,
                      r = 0.005,
                      s = 0.95,
-                     eps = 0.001
+                     eps = 0.001,
+                     showall=false,
+                     section=:parameters
                     )
-     _, p, m = size(c.value)
+    c = showall ? sort(chn) : Chains(chn, section; sorted=true)
+    _, p, m = size(c.value)
     vals = Array{Float64}(undef, p, 5, m)
     for j in 1:p, k in 1:m
         vals[j, :, k] = rafterydiag(
@@ -71,8 +74,9 @@ function rafterydiag(
         )
     end
 
-    hdr = header(c) * "\nRaftery and Lewis Diagnostic:\n" *
-        "Quantile (q) = $q\nAccuracy (r) = $r\nProbability (s) = $s\n"
+    section_name = showall ? "" : "\n" * string(section) * "\n"
+    hdr = "Raftery and Lewis Diagnostic:\n" *
+        "Quantile (q) = $q\nAccuracy (r) = $r\nProbability (s) = $s\n" * section_name
 
     return ChainSummary(vals,
                         string.(names(c)),

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -32,11 +32,6 @@ chn = Chains(val, start = 1, thin = 2)
 end
 
 @testset "function tests" begin
-    # do not test the following functions
-    # - wrtsp
-    # - window2inds (tested above, see getindex)
-    # -
-
     # the following tests only check if the function calls work!
     @test MCMCChains.diag_all(rand(100, 2), :weiss, 1, 1, 1) != nothing
     @test MCMCChains.diag_all(rand(100, 2), :hangartner, 1, 1, 1) != nothing


### PR DESCRIPTION
Addresses #52 by adding support for diagnostic functions. You can now call `gelmandiag(chn, section=:internals)` to use a specific section (defaults to `:parameters`) or `gelmandiag(chn, showall=true)` which uses all variables in the chain. `gelmandiag(chn, section=[:pooled, :internals])` should also work if you want to call multiple sections. 

This works for all the diagnostic functions.