### PR TITLE
Cornerplot fix

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -28,11 +28,11 @@ const supportedplots = push!(collect(keys(translationdict)), :mixeddensity, :cor
 
     if colordim == :parameter
         title --> "Chain $(chains(c)[i])"
-        labels --> c
+        label --> names(c)
         val = c.value[:, :, i]
     elseif colordim == :chain
         title --> names(c)[i]
-        labels --> map(k -> "Chain $(chains(c)[k])", 1:size(c)[3])
+        label --> map(k -> "Chain $(chains(c)[k])", 1:size(c)[3])
         val = c.value[:, i, :]
     else
         throw(ArgumentError("`colordim` must be one of `:chain` or `:parameter`"))
@@ -137,7 +137,7 @@ end
         end
     else
         length(ptypes) > 1 && error(":corner is not compatible with multiple seriestypes")
-        Corner(c, Symbol.(keys(c)[parameters]))
+        Corner(c, names(c)[parameters])
     end
 end
 
@@ -150,5 +150,6 @@ end
     label --> permutedims(corner.parameters)
     compact --> true
     size --> (600, 600)
-    RecipesBase.recipetype(:cornerplot, reduce(hcat, corner.c[:,s,:] for s in corner.parameters))
+    ar = collect(Array(corner.c.value[:, corner.parameters,i]) for i in chains(corner.c))
+    RecipesBase.recipetype(:cornerplot, vcat(ar...))
 end


### PR DESCRIPTION
Currently the `corner` function wigs out when it's given an argument with multiple chains in it, so I've added functionality to flatten out a chain to allow it to plot.