### PR TITLE
Add set_section function

### DIFF
--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -5,7 +5,7 @@ import StatsBase: autocor, autocov, countmap, counts, describe, predict,
        quantile, sample, sem, summarystats
 import LinearAlgebra: diag
 import Serialization: serialize, deserialize
-import Base: sort, range, names
+import Base: sort, range, names, hash
 import Statistics: cor
 
 using RecipesBase
@@ -18,7 +18,7 @@ using AxisArrays
 const axes = Base.axes
 
 export Chains, getindex, setindex!, chains, setinfo, chainscat
-export describe
+export describe, set_section
 
 # export diagnostics functions
 export discretediag, gelmandiag, gewekediag, heideldiag, rafterydiag

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -432,6 +432,14 @@ function setinfo(c::Chains{A, T, K}, n::NamedTuple) where {A, T, K}
 end
 
 set_section(c::Chains, nt::NamedTuple) = set_section(c, _namedtuple2dict(nt))
+
+"""
+    set_section(c::Chains, nt::Dict)
+
+Changes a chains name mapping to a provided dictionary. This also supports a NamedTuple.
+Any parameters in the chain that are unassigned will be placed into
+the :parameters section.
+"""
 function set_section(c::Chains{A, T, K, L}, d::Dict) where {A,T,K,L}
     # Add :parameters if it's not there.
     if !(:parameters in keys(d))
@@ -446,9 +454,6 @@ function set_section(c::Chains{A, T, K, L}, d::Dict) where {A,T,K,L}
         end
     end
     missing_names = setdiff(names(c), nms)
-    println(nms)
-    println(names(c))
-    println(missing_names)
 
     # Assign everything to :parameters if anything's missing.
     if length(missing_names) > 0

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -200,7 +200,7 @@ function Base.show(io::IO, c::Chains)
     println(io, header(c))
 
     # Grab the value hash.
-    h = hash(c.value)
+    h = hash(c)
 
     if :hashedsummary in keys(c.info)
         s = c.info.hashedsummary.x
@@ -229,6 +229,11 @@ Base.step(c::AbstractChains) = step(c.value[Axis{:iter}].val)
 Base.last(c::AbstractChains) = last(c.value[Axis{:iter}].val)
 
 #################### Auxilliary Functions ####################
+
+function Base.hash(c::Chains)
+    val = hash(c.value) + hash(c.info) + hash(c.name_map) + hash(c.logevidence)
+    return hash(val)
+end
 
 function combine(c::AbstractChains)
   n, p, m = size(c.value)
@@ -426,6 +431,40 @@ function setinfo(c::Chains{A, T, K}, n::NamedTuple) where {A, T, K}
     )
 end
 
+set_section(c::Chains, nt::NamedTuple) = set_section(c, _namedtuple2dict(nt))
+function set_section(c::Chains{A, T, K, L}, d::Dict) where {A,T,K,L}
+    # Add :parameters if it's not there.
+    if !(:parameters in keys(d))
+        d[:parameters] = []
+    end
+
+    # Make sure all the names are in the new name map.
+    nms = Set([])
+    for values in values(d)
+        for val in values
+            push!(nms, val)
+        end
+    end
+    missing_names = setdiff(names(c), nms)
+    println(nms)
+    println(names(c))
+    println(missing_names)
+
+    # Assign everything to :parameters if anything's missing.
+    if length(missing_names) > 0
+        @warn "Section mapping does not contain all parameter names, " *
+            "$missing_names assigned to :parameters."
+        push!(d[:parameters], missing_names...)
+    end
+
+    nt = _dict2namedtuple(d)
+    return Chains{A, T, typeof(nt), L}(
+        c.value,
+        c.logevidence,
+        nt,
+        c.info
+    )
+end
 
 #################### Concatenation ####################
 

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -29,6 +29,7 @@ chn = Chains(val, start = 1, thin = 2)
     @test all(chn[:,1,2].value .== val[:,1,2])
     @test all(MCMCChains.indiscretesupport(chn) .== [false, false, false, true])
     @test setinfo(chn, NamedTuple{(:A, :B)}((1,2))).info == NamedTuple{(:A, :B)}((1,2))
+    @test set_section(chn, Dict(:internals => ["Param1"]))
 end
 
 @testset "function tests" begin

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -29,7 +29,7 @@ chn = Chains(val, start = 1, thin = 2)
     @test all(chn[:,1,2].value .== val[:,1,2])
     @test all(MCMCChains.indiscretesupport(chn) .== [false, false, false, true])
     @test setinfo(chn, NamedTuple{(:A, :B)}((1,2))).info == NamedTuple{(:A, :B)}((1,2))
-    @test set_section(chn, Dict(:internals => ["Param1"]))
+    @test isa(set_section(chn, Dict(:internals => ["Param1"])), MCMCChains.AbstractChains)
 end
 
 @testset "function tests" begin


### PR DESCRIPTION
Adds a `set_section` function which can be used to change the `name_map` of a chain to something other than the default.  This came up over [on Discourse](https://discourse.julialang.org/t/setting-up-multiple-chains-in-turing-jl/20806/22). Hat tip to @goedman.

Usage example:

```julia
val = rand(500, 5, 1)
chn = Chains(val, ["P[1]", "P[2]", "P[3]", "D", "E"]);

chn2 = set_section(chn, Dict(:internals => ["D", "E"]))
```

`chn2` will now have `D` and `E` in `:internals` while everything else defaults to `:parameters`. You can also pass in a `NamedTuple` if you are so inclined.

Note that this requires a new assignment (`chn2 = set_section(. . .)`) since the `name_map` field is immutable.