### PR TITLE
[RFC] Index functionality change

### DIFF
--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -18,7 +18,7 @@ using AxisArrays
 const axes = Base.axes
 
 export Chains, getindex, setindex!, chains, setinfo, chainscat
-export describe, set_section, get_all, sections
+export describe, set_section, get_params, sections
 
 # export diagnostics functions
 export discretediag, gelmandiag, gewekediag, heideldiag, rafterydiag

--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -5,7 +5,7 @@ import StatsBase: autocor, autocov, countmap, counts, describe, predict,
        quantile, sample, sem, summarystats
 import LinearAlgebra: diag
 import Serialization: serialize, deserialize
-import Base: sort, range, names
+import Base: sort, range, names, get
 import Statistics: cor
 
 using RecipesBase

--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -18,7 +18,7 @@ using AxisArrays
 const axes = Base.axes
 
 export Chains, getindex, setindex!, chains, setinfo, chainscat
-export describe, set_section
+export describe, set_section, get_all, sections
 
 # export diagnostics functions
 export discretediag, gelmandiag, gewekediag, heideldiag, rafterydiag

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -262,7 +262,7 @@ function Base.get(c::Chains; section::Union{Vector{Symbol}, Symbol})
 end
 
 """
-    get_all(c::Chains)
+    get_params(c::Chains)
 
 Returns all parameters packaged as a `NamedTuple`. Variables with a bracket
 in their name (as in "P[1]") will be grouped into the returned value as P.
@@ -270,11 +270,11 @@ in their name (as in "P[1]") will be grouped into the returned value as P.
 Example:
 
 ```julia
-x = get_all(chn)
+x = get_params(chn)
 x.P
 ```
 """
-get_all(c::Chains) = get(c, section = sections(c))
+get_params(c::Chains) = get(c, section = sections(c))
 
 #################### Base Methods ####################
 

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -188,14 +188,8 @@ end
 
 Base.setindex!(c::Chains, v, i...) = setindex!(c.value, v, i...)
 
-get_params1(c::Chains, v::Symbol) = get_params(c, [v])
-function get_params1(c::Chains, v::Vector{Symbol})
-    syms = _sym2index(c, v)
-    return ntuple(i -> c.value[:,syms[i],:], length(syms))
-end
-
-get_params2(c::Chains, v::Symbol) = get_params(c, [v])
-function get_params2(c::Chains, vs::Vector{Symbol})
+Base.get(c::Chains, v::Symbol) = get(c, [v])
+function Base.get(c::Chains, vs::Vector{Symbol})
     pairs = Dict()
     for v in vs
         syms = _sym2index(c, [v])

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -51,10 +51,10 @@ end
     v3 = rand(500, 4, 1)
     v4 = rand(500, 5, 4)
 
-    c1 = Chains(v1, [:a1, :a2, :a3, :a4, :a5])
-    c2 = Chains(v2, [:a1, :a2, :a3, :a4, :a5], start = 501)
-    c3 = Chains(v3, [:z1, :z2, :z3, :z4])
-    c4 = Chains(v4, [:a1, :a2, :a3, :a4, :a5])
+    c1 = Chains(v1, ["a1", "a2", "a3", "a4", "a5"])
+    c2 = Chains(v2, ["a1", "a2", "a3", "a4", "a5"], start = 501)
+    c3 = Chains(v3, ["z1", "z2", "z3", "z4"])
+    c4 = Chains(v4, ["a1", "a2", "a3", "a4", "a5"])
 
     # Test dim 1
     c1_2 = cat(c1, c2, dims = 1)

--- a/test/get_tests.jl
+++ b/test/get_tests.jl
@@ -1,0 +1,24 @@
+using MCMCChains
+using Turing
+using Test
+
+@testset "get tests" begin
+    @model model(x) = begin
+        m = Vector{Real}(undef, 10)
+        [m[i] ~ Normal(0, 0.5) for i in 1:10]
+        s ~ InverseGamma(2,3)
+        x ~ Normal(0, s)
+    end
+
+    model = model(2.0)
+    sampler = HMC(500, 0.01, 5)
+    chn = sample(model, sampler)
+
+    get1 = get(chn, :m)
+    get2 = get(chn, [:m, :s])
+    
+    @test length(get1.m) == 10
+    @test length(get1.m[5]) == 500
+    @test length(get2.s) == 500
+    @test collect(keys(get2)) == [:m, :s]
+end

--- a/test/get_tests.jl
+++ b/test/get_tests.jl
@@ -28,7 +28,7 @@ using Test
     getsection = get(chn, section = :internals)
     @test length(keys(getsection)) == 2
 
-    getall = get_all(chn)
+    getall = get_params(chn)
     @test getall == get(chn, section=[:internals, :parameters])
     @test length(keys(getall)) == 4
 end

--- a/test/get_tests.jl
+++ b/test/get_tests.jl
@@ -5,20 +5,23 @@ using Test
 @testset "get tests" begin
     @model model(x) = begin
         m = Vector{Real}(undef, 10)
-        [m[i] ~ Normal(0, 0.5) for i in 1:10]
+        [m[i] ~ Normal(i, 0.1) for i in 1:10]
         s ~ InverseGamma(2,3)
         x ~ Normal(0, s)
     end
 
+    n_samples = 1000
     model = model(2.0)
-    sampler = HMC(500, 0.01, 5)
+    sampler = MH(n_samples)
     chn = sample(model, sampler)
 
     get1 = get(chn, :m)
     get2 = get(chn, [:m, :s])
-    
+
     @test length(get1.m) == 10
-    @test length(get1.m[5]) == 500
-    @test length(get2.s) == 500
+    @test length(get1.m[5]) == n_samples
+    @test round(mean(get1.m[1])) ≈ 1.0
+    @test round(mean(get1.m[10])) ≈ 10.0
+    @test length(get2.s) == n_samples
     @test collect(keys(get2)) == [:m, :s]
 end

--- a/test/get_tests.jl
+++ b/test/get_tests.jl
@@ -24,4 +24,11 @@ using Test
     @test round(mean(get1.m[10])) ≈ 10.0
     @test length(get2.s) == n_samples
     @test collect(keys(get2)) == [:m, :s]
+
+    getsection = get(chn, section = :internals)
+    @test length(keys(getsection)) == 2
+
+    getall = get_all(chn)
+    @test getall == get(chn, section=[:internals, :parameters])
+    @test length(keys(getall)) == 4
 end

--- a/test/sections_tests.jl
+++ b/test/sections_tests.jl
@@ -11,18 +11,18 @@ using  MCMCChains, Test
     p = filter(p -> !(p in  pi), cnames)
 
     c = Chains(a3d,
-        Symbol.(cnames),
+        cnames,
             Dict(
-                :parameters => Symbol.(p),
-                :internals => Symbol.(pi)
+                :parameters => p,
+                :internals => pi
                 )
         )
 
     c2 = Chains(a3d,
-        Symbol.(cnames),
+        cnames,
             Dict(
-                :parameters => Symbol.(p),
-                :internals => Symbol.(pi)
+                :parameters => p,
+                :internals => pi
             )
         )
 


### PR DESCRIPTION
Addresses #53 by forcing `chn[:D]` and `chn[:, "D", :]` to both return `Chains` objects. This is a request for comments, so please let me know if you don't like this change or want to add/drop things.

Example:

```julia
chn[:, "D", :]
```
```
Object of type Chains, with data of type 500×1×1 Array{Union{Missing, Float64},3}

Log evidence      = 0.0
Iterations        = 1:500
Thinning interval = 1
Chains            = Chain1
Samples per chain = 500
parameters        = D

parameters
   Mean    SD   Naive SE  MCSE     ESS  
D 0.4872 0.2823   0.0126 0.0139 412.6237
```

and 

```julia
chn[:D]
```
```
Object of type Chains, with data of type 500×1×1 Array{Union{Missing, Float64},3}

Log evidence      = 0.0
Iterations        = 1:500
Thinning interval = 1
Chains            = Chain1
Samples per chain = 500
parameters        = D

parameters
   Mean    SD   Naive SE  MCSE     ESS  
D 0.4872 0.2823   0.0126 0.0139 412.6237
```

Users can still extract numerical data if they so wish using `chn[:D].value`. 

I have also added a fairly handy function `get`, which functions very similarly to how `chn[:D]` used to function on the Turing side, but with some extra bells and whistles. I became fed up working with the `AxisArrays` based indexing while trying to update Turing's tutorials, and decided it would be a good idea to provide some support for significantly simpler indexing. `get(chn, :P)` returns a `NamedTuple` which is very easy to work with (in my opinion).

Example:

```julia
val = rand(500, 5, 1)
chn = Chains(val, ["P[1]", "P[2]", "P[3]", "D", "E"]);

x = get(chn, :P)
```

Here's what `x` looks like:

```julia
(P = (Union{Missing, Float64}[0.349592; 0.671365; … ; 0.319421; 0.298899], Union{Missing, Float64}[0.757884; 0.720212; … ; 0.471339; 0.5381], Union{Missing, Float64}[0.240626; 0.987814; … ; 0.980652; 0.149805]),)
```

You can access each of the `P[. . .]` variables by indexing, using `x.P[1]`, `x.P[2]`, or `x.P[3]`. This makes it _very_ easy to work with high dimensional vectors put out by Turing. Hopefully this is also helpful on the StanJulia side.

`get` also accepts vectors of things to get, so you can call `x = get(chn, [:P, :D])`. This looks like

```julia
(P = (Union{Missing, Float64}[0.349592; 0.671365; … ; 0.319421; 0.298899], Union{Missing, Float64}[0.757884; 0.720212; … ; 0.471339; 0.5381], Union{Missing, Float64}[0.240626; 0.987814; … ; 0.980652; 0.149805]), 
 D = Union{Missing, Float64}[0.648963; 0.0419232; … ; 0.54666; 0.746028])
```

Note that `x.P` is a tuple which has to be indexed by the relevant index, while `x.D` is just a vector.