### PR TITLE
Fix display error when :parameters doesn't exist 

### DIFF
--- a/src/stats.jl
+++ b/src/stats.jl
@@ -9,6 +9,9 @@ function autocor(chn::AbstractChains;
     # Allocation of summary vector.
     summaries = Vector{ChainSummary}([])
 
+    # Check that we actually have :parameters.
+    showall = showall ? true : _use_showall(chn, section)
+
     # Separate the chain into sections if showall=false.
     chns = showall ? [chn] : get_sections(chn, section)
 
@@ -58,6 +61,9 @@ function cor(chn::AbstractChains;
     # Allocation of summary vector.
     summaries = Vector{ChainSummary}([])
 
+    # Check that we actually have :parameters.
+    showall = showall ? true : _use_showall(chn, section)
+
     # Separate the chain into sections if showall=false.
     chns = showall ? [chn] : get_sections(chn, section)
 
@@ -84,6 +90,9 @@ function changerate(chn::AbstractChains;
     showall=false, suppress_header=false, section=:parameters)
     # Check for missing values.
     @assert !any(ismissing.(chn.value)) "Change rate comp. doesn't support missing values."
+
+    # Check that we actually have :parameters.
+    showall = showall ? true : _use_showall(chn, section)
 
     # Allocation of summary vector.
     summaries = Vector{ChainSummary}([])
@@ -139,6 +148,10 @@ function describe(io::IO,
                   section=:parameters,
                   args...
                  )
+
+    # Check that we actually have :parameters.
+    showall = showall ? true : _use_showall(chn, section)
+
     # Print the chain header.
     println(io, header(c, section = showall ? missing : section))
 
@@ -186,6 +199,9 @@ function hpd(chn::AbstractChains; alpha::Real=0.05,
     # Allocation summary vector.
     summaries = Vector{ChainSummary}([])
 
+    # Check that we actually have :parameters.
+    showall = showall ? true : _use_showall(chn, section)
+
     # Separate the chain into sections if showall=false.
     chns = showall ? [chn] : get_sections(chn, section)
 
@@ -218,6 +234,9 @@ function quantile(chn::AbstractChains; q::Vector=[0.025, 0.25, 0.5, 0.75, 0.975]
     # Allocation summary vector.
     summaries = Vector{ChainSummary}([])
 
+    # Check that we actually have :parameters.
+    showall = showall ? true : _use_showall(chn, section)
+
     # Separate the chain into sections if showall=false.
     chns = showall ? [chn] : get_sections(chn, section)
 
@@ -249,6 +268,9 @@ function summarystats(chn::AbstractChains; etype=:bm,
     # Allocation summary vector.
     summaries = Vector{ChainSummary}([])
 
+    # Check that we actually have :parameters.
+    showall = showall ? true : _use_showall(chn, section)
+    
     # Summary statistics function array.
     f(x) = [mean(x),
         std(x),
@@ -263,7 +285,7 @@ function summarystats(chn::AbstractChains; etype=:bm,
 
     length(chn) >= 200 || @warn "Chain iterations are < 200, " *
         "MCSE and ESS cannot be computed."
-        
+
     # Separate the chain into sections if showall=false.
     chns = showall ? [chn] : get_sections(chn, section)
 

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -150,7 +150,7 @@ function describe(io::IO,
                  )
 
     # Check that we actually have :parameters.
-    showall = showall ? true : _use_showall(chn, section)
+    showall = showall ? true : _use_showall(c, section)
 
     # Print the chain header.
     println(io, header(c, section = showall ? missing : section))
@@ -270,7 +270,7 @@ function summarystats(chn::AbstractChains; etype=:bm,
 
     # Check that we actually have :parameters.
     showall = showall ? true : _use_showall(chn, section)
-    
+
     # Summary statistics function array.
     f(x) = [mean(x),
         std(x),

--- a/test/sections_tests.jl
+++ b/test/sections_tests.jl
@@ -2,7 +2,7 @@ using  MCMCChains, Test
 
 @testset "describe sections" begin
 
-    a3d = reshape(1:3600, 100, 9, 4)
+    a3d = rand(500, 9, 4)
 
     cnames = ["lp__"  , "accept_stat__", "stepsize__" , "treedepth__" ,
         "n_leapfrog__" , "divergent__"  , "energy__", "sigma", "mu" ]


### PR DESCRIPTION
Addresses #61 by showing the entire chain when `:parameters` is not in the section map. Also includes some miscellaneous indexing improvements.