### PR TITLE
Sampling api

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ RecipesBase 0.5.0
 SpecialFunctions 0.7.0
 Distributions 0.16.2
 AxisArrays 0.3.0
+KernelDensity 0.5.1

--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -2,7 +2,7 @@ module MCMCChains
 
 import Showoff: showoff
 import StatsBase: autocor, autocov, countmap, counts, describe, predict,
-       quantile, sample, sem, summarystats
+       quantile, sample, sem, summarystats, sample, AbstractWeights
 import LinearAlgebra: diag
 import Serialization: serialize, deserialize
 import Base: sort, range, names, get, hash
@@ -13,12 +13,14 @@ import RecipesBase: plot
 
 using Serialization
 using Distributions
+using KernelDensity
 using SpecialFunctions
 using AxisArrays
 const axes = Base.axes
 
 export Chains, getindex, setindex!, chains, setinfo, chainscat
 export describe, set_section, get_params, sections
+export sample, AbstractWeights
 
 # export diagnostics functions
 export discretediag, gelmandiag, gewekediag, heideldiag, rafterydiag
@@ -57,6 +59,7 @@ include("mcse.jl")
 #include("modelchains.jl")
 #include("modelstats.jl")
 include("rafterydiag.jl")
+include("sampling.jl")
 include("stats.jl")
 include("plot.jl")
 #include("plot2.jl")

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -1,0 +1,50 @@
+import StatsBase: sample
+using Random, KernelDensity
+
+function sample(rng::AbstractRNG, chn::MCMCChains.AbstractChains, n;
+    replace=true, ordered=false) 
+  indxs = sample(rng, 
+    range(chn),
+    n,
+    replace=replace, ordered=ordered)
+  return Chains(chn.value[indxs, :, :],
+    names(chn), 
+    chn.name_map,
+    info = chn.info)
+end
+
+function sample(chn::MCMCChains.AbstractChains, n;
+    replace=true, ordered=false)
+  indxs = sample(Random.GLOBAL_RNG,
+    range(chn),
+    n,
+    replace=replace, ordered=ordered)
+  return Chains(chn.value[indxs, :, :],
+    names(chn),
+    chn.name_map,
+    info = chn.info)
+end
+
+function sample(rng::AbstractRNG, chn::MCMCChains.AbstractChains,
+    wv::AbstractWeights, n) 
+  indxs = sample(rng, 
+    range(chn), 
+    wv, 
+    n)
+  return Chains(chn.value[indxs, :, :],
+    names(chn),
+    chn.name_map,
+    info = chn.info)
+end
+
+function sample(chn::MCMCChains.AbstractChains,
+    wv::AbstractWeights, n) 
+  indxs = sample(Random.GLOBAL_RNG, 
+    range(chn), 
+    wv, 
+    n)
+    return Chains(chn.value[indxs, :, :],
+      names(chn),
+      chn.name_map,
+      info = chn.info)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,3 +24,6 @@ include("sections_tests.jl")
 
 # run tests for missing values
 include("serialization_tests.jl")
+
+# run tests for sampoling api
+include("sampling_tests.jl")

--- a/test/sampling_tests.jl
+++ b/test/sampling_tests.jl
@@ -1,5 +1,5 @@
-using Turing, MCMCChains, KernelDensity, Test, Statistics
-import StatsBase: sample, AbstractWeights
+using Turing, MCMCChains, KernelDensity, StatsBase, Test, Statistics
+import StatsBase: sample
 
 @testset "sampling api" begin
 

--- a/test/sampling_tests.jl
+++ b/test/sampling_tests.jl
@@ -1,10 +1,9 @@
-#using Turing, MCMCChains, StatsBase, Random, KernelDensity, Test, Statistics
 using Turing, MCMCChains, Test, Statistics
 import StatsBase: sample, AbstractWeights
 
 @model gdemo(x) = begin
-    s ~ Normal(5, 0.01)
     m ~ Normal(1, 0.01)
+    s ~ Normal(5, 0.01)
 end
 
 model = gdemo([1.5, 2.0])

--- a/test/sampling_tests.jl
+++ b/test/sampling_tests.jl
@@ -1,0 +1,20 @@
+#using Turing, MCMCChains, StatsBase, Random, KernelDensity, Test, Statistics
+using Turing, MCMCChains, Test, Statistics
+import StatsBase: sample, AbstractWeights
+
+@model gdemo(x) = begin
+    s ~ Normal(5, 0.01)
+    m ~ Normal(1, 0.01)
+end
+
+model = gdemo([1.5, 2.0])
+sampler = HMC(500, 0.01, 5)
+chn = sample(model, sampler, save_state=true);
+
+chn_sample = sample(chn, 5)
+@test range(chn_sample) == 1:1:5
+
+c = kde(reshape(convert(Array{Float64}, chn[:s].value), 500))
+chn_weighted_sample = sample(c.x, Weights(c.density), 100000)
+
+@test 4.9 < mean(reshape(convert(Array{Float64}, chn[:s].value), 500)) < 5.1

--- a/test/sampling_tests.jl
+++ b/test/sampling_tests.jl
@@ -1,19 +1,23 @@
-using Turing, MCMCChains, Test, Statistics
+using Turing, MCMCChains, KernelDensity, Test, Statistics
 import StatsBase: sample, AbstractWeights
 
-@model gdemo(x) = begin
-    m ~ Normal(1, 0.01)
-    s ~ Normal(5, 0.01)
+@testset "sampling api" begin
+
+  @model gdemo(x) = begin
+      m ~ Normal(1, 0.01)
+      s ~ Normal(5, 0.01)
+  end
+
+  model = gdemo([1.5, 2.0])
+  sampler = HMC(500, 0.01, 5)
+  chn = sample(model, sampler, save_state=true);
+
+  chn_sample = sample(chn, 5)
+  @test range(chn_sample) == 1:1:5
+
+  c = kde(reshape(convert(Array{Float64}, chn[:s].value), 500))
+  chn_weighted_sample = sample(c.x, Weights(c.density), 100000)
+
+  @test 4.9 < mean(reshape(convert(Array{Float64}, chn[:s].value), 500)) < 5.1
+
 end
-
-model = gdemo([1.5, 2.0])
-sampler = HMC(500, 0.01, 5)
-chn = sample(model, sampler, save_state=true);
-
-chn_sample = sample(chn, 5)
-@test range(chn_sample) == 1:1:5
-
-c = kde(reshape(convert(Array{Float64}, chn[:s].value), 500))
-chn_weighted_sample = sample(c.x, Weights(c.density), 100000)
-
-@test 4.9 < mean(reshape(convert(Array{Float64}, chn[:s].value), 500)) < 5.1

--- a/test/sampling_tests.jl
+++ b/test/sampling_tests.jl
@@ -17,6 +17,6 @@ using Turing, MCMCChains, KernelDensity, StatsBase, Test, Statistics
   c = kde(reshape(convert(Array{Float64}, chn[:s].value), 500))
   chn_weighted_sample = sample(c.x, Weights(c.density), 100000)
 
-  @test mean(convert(Array{Float64}, chn[:s].value)) ≈ 5.0 atol=0.01
+  @test mean(convert(Array{Float64}, chn[:s].value)) ≈ 5.0 atol=0.1
 
 end

--- a/test/sampling_tests.jl
+++ b/test/sampling_tests.jl
@@ -1,5 +1,4 @@
 using Turing, MCMCChains, KernelDensity, StatsBase, Test, Statistics
-import StatsBase: sample
 
 @testset "sampling api" begin
 
@@ -18,6 +17,6 @@ import StatsBase: sample
   c = kde(reshape(convert(Array{Float64}, chn[:s].value), 500))
   chn_weighted_sample = sample(c.x, Weights(c.density), 100000)
 
-  @test 4.9 < mean(reshape(convert(Array{Float64}, chn[:s].value), 500)) < 5.1
+  @test mean(convert(Array{Float64}, chn[:s].value)) ≈ 5.0 atol=0.01
 
 end


### PR DESCRIPTION
This PR contains a proposed (simplified) sampling API as defined in StatsBase on top of MCMCChains.Chains objects as requested in #66.

It supports random sampling of draws in chains and sampling based on a Weights vector. This PR overloads StatsBase.sample() for that purpose and uses KernelDensity.kde() to compute a support range and associated densities. It is certainly possible to drop the KernelDensity dependency (although implicitly it is there through the density() plot).