### PR TITLE
Added export constructors (I used the wrong local branch name).

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ SpecialFunctions 0.7.0
 Distributions 0.16.2
 AxisArrays 0.3.0
 KernelDensity 0.5.1
+DataFrames 0.17.1

--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -7,6 +7,8 @@ import LinearAlgebra: diag
 import Serialization: serialize, deserialize
 import Base: sort, range, names, get, hash
 import Statistics: cor
+import Core.Array
+import DataFrames: DataFrame
 
 using RecipesBase
 import RecipesBase: plot
@@ -21,6 +23,7 @@ const axes = Base.axes
 export Chains, getindex, setindex!, chains, setinfo, chainscat
 export describe, set_section, get_params, sections
 export sample, AbstractWeights
+export Array, DataFrame, sort_sections
 
 # export diagnostics functions
 export discretediag, gelmandiag, gewekediag, heideldiag, rafterydiag
@@ -50,6 +53,7 @@ include("utils.jl")
 
 include("chains.jl")
 include("chainsummary.jl")
+include("constructors.jl")
 include("discretediag.jl")
 include("fileio.jl")
 include("gelmandiag.jl")

--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -5,7 +5,7 @@ import StatsBase: autocor, autocov, countmap, counts, describe, predict,
        quantile, sample, sem, summarystats, sample, AbstractWeights
 import LinearAlgebra: diag
 import Serialization: serialize, deserialize
-import Base: sort, range, names, get, hash
+import Base: sort, range, names, get, hash, convert
 import Statistics: cor
 import Core.Array
 import DataFrames: DataFrame
@@ -23,7 +23,7 @@ const axes = Base.axes
 export Chains, getindex, setindex!, chains, setinfo, chainscat
 export describe, set_section, get_params, sections
 export sample, AbstractWeights
-export Array, DataFrame, sort_sections
+export Array, DataFrame, sort_sections, convert
 
 # export diagnostics functions
 export discretediag, gelmandiag, gewekediag, heideldiag, rafterydiag

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -335,6 +335,8 @@ Base.first(c::AbstractChains) = first(c.value[Axis{:iter}].val)
 Base.step(c::AbstractChains) = step(c.value[Axis{:iter}].val)
 Base.last(c::AbstractChains) = last(c.value[Axis{:iter}].val)
 
+Base.convert(::Type{Array}, chn::MCMCChains.Chains) = convert(Array, chn.value)
+
 #################### Auxilliary Functions ####################
 
 function Base.hash(c::Chains)

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -1,0 +1,205 @@
+function sort_sections(chn::MCMCChains.AbstractChains)
+  smap = keys(chn.name_map)
+  section_list = Vector{Symbol}(undef, length(smap))
+  indx = 1
+  if :parameters in smap
+    section_list[1] = :parameters
+    indx += 1
+  end
+  if :internals in smap
+    section_list[end] = :internals
+  end
+  for par in smap
+    if !(par in [:parameters, :internals])
+      section_list[indx] = par
+      indx += 1
+    end
+  end
+  section_list
+end
+
+"""
+
+# Array
+
+Array constructor from an MCMCChains.Chains object. Returns 3 dimensionsal
+array or and Array of 2 dimensional Arrays. If only a single parameter if selected for
+inclusion, a dimension is dropped in both cases, as is e.g. required by cde(), etc.
+
+### Method
+```julia
+  Array(
+    chn::MCMCChains.AbstractChains, 
+    sections::Vector{Symbo);
+    append_chains::Bool,
+    remove_missing_union::Bool
+  )
+```
+
+### Required arguments
+```julia
+* `chn` : Chains object to convert to an Array
+* `sections = Symbol[]` : Sections form the Chains object to be included
+```
+
+### Optional arguments
+```julia
+* `append_chains=true`  : Append chains into a single column
+* ` remove_missing_union=true`  : Convert Union{Missing, Real} to Float64
+```
+
+### Examples
+```julia
+* `Array(chns)` : Array with chain values are appended
+* `Array(chns[:par])` : Array with selected parameter chain values are appended
+* `Array(chns, [:parameters])`  : Array with only :parameter section
+* `Array(chns, [:parameters, :internals])`  : Array also includes :internals section
+* `Array(chns, append_chains=false)`  : Array of Arrays, each chain in its own array
+* `Array(chns, remove_missing_union=false)` : No conversion to remove missing values
+```
+
+"""
+function Array(chn::MCMCChains.AbstractChains, 
+     sections::Vector{Symbol}=Symbol[];
+     append_chains=true, remove_missing_union=true)
+     
+  section_list = length(sections) == 0 ? sort_sections(chn) : sections
+  d, p, c = size(chn.value.data)
+
+  local b
+  if append_chains
+    first_parameter = true
+    for section in section_list
+      for par in chn.name_map[section]
+        x = get(chn, Symbol(par))
+        d, c = size(x[Symbol(par)])
+        if first_parameter
+          if remove_missing_union
+            b = reshape(convert(Array{Float64}, x[Symbol(par)]), d*c)[:, 1]
+          else
+            b = reshape(x[Symbol(par)], d*c)[:, 1]
+          end
+          p == 1 && (b = reshape(b, size(b, 1)))
+          first_parameter = false
+        else
+          if remove_missing_union
+            b = hcat(b, reshape(convert(Array{Float64}, x[Symbol(par)]), d*c)[:, 1])
+          else
+            b = hcat(b, reshape(x[Symbol(par)], d*c)[:, 1])
+          end
+        end
+      end
+    end
+  else
+    b=Vector(undef, c)
+    for i in 1:c
+      first_parameter = true
+      for section in section_list
+        for par in chn.name_map[section]
+          x = get(chn, Symbol(par))
+          d, c = size(x[Symbol(par)])
+          if first_parameter
+            if remove_missing_union
+              b[i] = convert(Array{Real}, x[Symbol(par)][:, i])
+            else
+              b[i] = x[Symbol(par)][:, i]
+            end
+            p == 1 && (b[i] = reshape(b[i], size(b[i], 1)))
+            first_parameter = false
+          else
+            if remove_missing_union
+              b[i] = hcat(b[i], convert(Array{Real}, x[Symbol(par)][:, i]))
+            else
+              b[i] = hcat(b[i], x[Symbol(par)][:, i])
+            end
+          end
+        end
+      end
+    end
+  end
+  b
+end  
+
+
+"""
+
+# DataFrame
+
+DataFrame constructor from an MCMCChains.Chains object. 
+Returns either a DataFrame or an Array{DataFrame}
+
+### Method
+```julia
+  DataFrame(
+    chn::MCMCChains.AbstractChains, 
+    sections::Vector{Symbo);
+    append_chains::Bool,
+    remove_missing_union::Bool
+  )
+```
+
+### Required arguments
+```julia
+* `chn` : Chains object to convert to an DataFrame
+* `sections = Symbol[]` : Sections form the Chains object to be included
+```
+
+### Optional arguments
+```julia
+* `append_chains=true`  : Append chains into a single column
+* ` remove_missing_union=true`  : Remove Union{Missing, Real} and AxisArray stuff
+```
+
+### Examples
+```julia
+* `DataFrame(chns)` : DataFrame with chain values are appended
+* `DataFrame(chns[:par])` : DataFrame with single parameter (chain values are appended)
+* `DataFrame(chns, [:parameters])`  : DataFrame with only :parameter section
+* `DataFrame(chns, [:parameters, :internals])`  : DataFrame also includes :internals section
+* `DataFrame(chns, append_chains=false)`  : Array of DataFrame, each chain in its own array
+* `DataFrame(chns, remove_missing_union=false)` : No conversion to remove missing values
+```
+
+"""
+function DataFrame(chn::MCMCChains.AbstractChains,
+    sections::Vector{Symbol}=Symbol[];
+    append_chains=true, remove_missing_union=true)
+    
+  section_list = length(sections) == 0 ? sort_sections(chn) : sections
+  d, p, c = size(chn.value.data)
+
+  local b
+  if append_chains
+    b = DataFrame()
+    for section in section_list
+      for par in chn.name_map[section]
+          x = get(chn, Symbol(par))
+          d, c = size(x[Symbol(par)])
+          if remove_missing_union
+            b = hcat(b, DataFrame(Symbol(par) => reshape(convert(Array{Float64}, 
+              x[Symbol(par)]), d*c)[:, 1]))
+          else
+            b = hcat(b, DataFrame(Symbol(par) => reshape(x[Symbol(par)], d*c)[:, 1]))
+          end
+      end
+    end
+  else
+    b = Vector{DataFrame}(undef, c)
+    for i in 1:c
+      b[i] = DataFrame()
+      for section in section_list
+        for par in chn.name_map[section]
+            x = get(chn, Symbol(par))
+            d, c = size(x[Symbol(par)])
+            if remove_missing_union
+              b[i] = hcat(b[i], DataFrame(Symbol(par) => convert(Array{Float64}, 
+                x[Symbol(par)])[:, 1]))
+            else
+              b[i] = hcat(b[i], DataFrame(Symbol(par) => x[Symbol(par)][:,1]))
+            end
+        end
+      end
+    end
+  end
+  b
+end

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -29,7 +29,7 @@ inclusion, a dimension is dropped in both cases, as is e.g. required by cde(), e
 ### Method
 ```julia
   Array(
-    chn::MCMCChains.AbstractChains, 
+    chn::MCMCChains.AbstractChains,
     sections::Vector{Symbo);
     append_chains::Bool,
     remove_missing_union::Bool
@@ -59,10 +59,10 @@ inclusion, a dimension is dropped in both cases, as is e.g. required by cde(), e
 ```
 
 """
-function Array(chn::MCMCChains.AbstractChains, 
+function Array(chn::MCMCChains.AbstractChains,
      sections::Vector{Symbol}=Symbol[];
      append_chains=true, remove_missing_union=true)
-     
+
   section_list = length(sections) == 0 ? sort_sections(chn) : sections
   d, p, c = size(chn.value.data)
 
@@ -118,20 +118,21 @@ function Array(chn::MCMCChains.AbstractChains,
     end
   end
   b
-end  
+end
 
+Base.convert(::Type{Array}, chn::MCMCChains.Chains) = convert(Array, chn.value)
 
 """
 
 # DataFrame
 
-DataFrame constructor from an MCMCChains.Chains object. 
+DataFrame constructor from an MCMCChains.Chains object.
 Returns either a DataFrame or an Array{DataFrame}
 
 ### Method
 ```julia
   DataFrame(
-    chn::MCMCChains.AbstractChains, 
+    chn::MCMCChains.AbstractChains,
     sections::Vector{Symbo);
     append_chains::Bool,
     remove_missing_union::Bool
@@ -164,7 +165,7 @@ Returns either a DataFrame or an Array{DataFrame}
 function DataFrame(chn::MCMCChains.AbstractChains,
     sections::Vector{Symbol}=Symbol[];
     append_chains=true, remove_missing_union=true)
-    
+
   section_list = length(sections) == 0 ? sort_sections(chn) : sections
   d, p, c = size(chn.value.data)
 
@@ -176,7 +177,7 @@ function DataFrame(chn::MCMCChains.AbstractChains,
           x = get(chn, Symbol(par))
           d, c = size(x[Symbol(par)])
           if remove_missing_union
-            b = hcat(b, DataFrame(Symbol(par) => reshape(convert(Array{Float64}, 
+            b = hcat(b, DataFrame(Symbol(par) => reshape(convert(Array{Float64},
               x[Symbol(par)]), d*c)[:, 1]))
           else
             b = hcat(b, DataFrame(Symbol(par) => reshape(x[Symbol(par)], d*c)[:, 1]))
@@ -192,7 +193,7 @@ function DataFrame(chn::MCMCChains.AbstractChains,
             x = get(chn, Symbol(par))
             d, c = size(x[Symbol(par)])
             if remove_missing_union
-              b[i] = hcat(b[i], DataFrame(Symbol(par) => convert(Array{Float64}, 
+              b[i] = hcat(b[i], DataFrame(Symbol(par) => convert(Array{Float64},
                 x[Symbol(par)])[:, 1]))
             else
               b[i] = hcat(b[i], DataFrame(Symbol(par) => x[Symbol(par)][:,1]))

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -39,7 +39,7 @@ inclusion, a dimension is dropped in both cases, as is e.g. required by cde(), e
 ### Required arguments
 ```julia
 * `chn` : Chains object to convert to an Array
-* `sections = Symbol[]` : Sections form the Chains object to be included
+* `sections = Symbol[]` : Sections from the Chains object to be included
 ```
 
 ### Optional arguments

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -23,7 +23,7 @@ end
 # Array
 
 Array constructor from an MCMCChains.Chains object. Returns 3 dimensionsal
-array or and Array of 2 dimensional Arrays. If only a single parameter if selected for
+array or an Array of 2 dimensional Arrays. If only a single parameter is selected for
 inclusion, a dimension is dropped in both cases, as is e.g. required by cde(), etc.
 
 ### Method

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -30,7 +30,7 @@ inclusion, a dimension is dropped in both cases, as is e.g. required by cde(), e
 ```julia
   Array(
     chn::MCMCChains.AbstractChains,
-    sections::Vector{Symbo);
+    sections::Vector{Symbol};
     append_chains::Bool,
     remove_missing_union::Bool
   )

--- a/test/arrayconstructor_tests.jl
+++ b/test/arrayconstructor_tests.jl
@@ -1,0 +1,38 @@
+using Turing, MCMCChains, Test
+
+@testset "Array constructor tests" begin
+  
+  @model gdemo(x) = begin
+      m ~ Normal(1, 0.01)
+      s ~ Normal(5, 0.01)
+  end
+
+  model = gdemo([1.5, 2.0])
+  sampler = HMC(1000, 0.01, 5)
+
+  chns = [sample(model, sampler, save_state=true) for i in 1:4]
+  chns = chainscat(chns...) 
+  
+  d, p, c = size(chns.value.data)
+
+  @test size(Array(chns)) == (d*c, p)
+  @test size(Array(chns, [:parameters])) == (d*c, 2)
+  @test size(Array(chns, [:parameters, :internals])) == (d*c, p)
+  @test size(Array(chns, [:internals])) == (d*c, 6)
+  @test size(Array(chns, append_chains=true)) == (d*c, p)
+  @test size(Array(chns, append_chains=false)) == (4,)
+  @test size(Array(chns, append_chains=false)[1]) == (d, p)
+  @test typeof(Array(chns, append_chains=true)) == Array{Float64, 2}
+  @test size(Array(chns, remove_missing_union=false)) == (d*c, p)
+  @test size(Array(chns, append_chains=false, remove_missing_union=false)) == (4,)
+  @test size(Array(chns, append_chains=false, remove_missing_union=false)[1]) == (d, p)
+  @test typeof(Array(chns, append_chains=true, remove_missing_union=false)) == 
+    Array{Union{Missing, Float64}, 2}
+  @test size(Array(chns[:m])) == (d*c,)
+
+  Array(chns)
+  Array(chns[:s])
+  Array(chns, [:parameters])
+  Array(chns, [:parameters, :internals])
+  
+end

--- a/test/dfconstructor_tests.jl
+++ b/test/dfconstructor_tests.jl
@@ -1,0 +1,47 @@
+using Turing, MCMCChains, Test
+
+@testset "DataFrame constructor tests" begin
+  
+  @model gdemo(x) = begin
+      m ~ Normal(1, 0.01)
+      s ~ Normal(5, 0.01)
+  end
+
+  model = gdemo([1.5, 2.0])
+  sampler = HMC(1000, 0.01, 5)
+
+  chns = [sample(model, sampler, save_state=true) for i in 1:4]
+  chn = chainscat(chns...)
+  
+  df = DataFrame(chn)
+  @test size(df) == (4000, 8)
+  
+  df1 = DataFrame(chn, [:parameters])
+  @test size(df1) == (4000, 2)
+  
+  df2 = DataFrame(chn, [:internals, :parameters])
+  @test size(df2) == (4000, 8)
+  
+  df3 = DataFrame(chn[:s]) 
+  @test size(df3) == (4000, 1)
+  
+  df4 = DataFrame(chn[:lp])  
+  @test size(df4) == (4000, 1)
+  
+  df5 = DataFrame(chn, [:parameters], append_chains=false)  
+  @test size(df5) == (4, )
+  @test size(df5[1]) == (1000, 2)
+
+  df6 = DataFrame(chn, [:parameters, :internals], append_chains=false)  
+  @test size(df6) == (4, )
+  @test size(df6[1]) == (1000, 8)
+
+  df7 = DataFrame(chn, [:parameters, :internals], remove_missing_union=false)  
+  @test size(df7) == (4000, 8)
+
+  df8 = DataFrame(chn, [:parameters, :internals], remove_missing_union=false,
+    append_chains=false)  
+  @test size(df8) == (4, )
+  @test size(df8[1]) == (1000, 8)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,3 +27,9 @@ include("serialization_tests.jl")
 
 # run tests for sampoling api
 include("sampling_tests.jl")
+
+# run tests for array constructor
+include("arrayconstructor_tests.jl")
+
+# run tests for dataframe constructor
+include("dfconstructor_tests.jl")


### PR DESCRIPTION
Added Array and DataFrame constructors and associated tests.

These constructors are intended as being used at the back-end of mcmc workflows, thus after checking for valid samples has been completed. Both the Array and DataFrame constructors are overloaded.

Simple help is available using ?Array and ?DataFrame once MCMCChains is loaded.