### PR TITLE
Fix weight misspecification for quantiles

### DIFF
--- a/src/stats.jl
+++ b/src/stats.jl
@@ -244,7 +244,7 @@ function quantile(chn::AbstractChains; q::Vector=[0.025, 0.25, 0.5, 0.75, 0.975]
     show_labels = true
 
     # Quantile weights.
-    w = [0.0, 0.25, 0.5, 0.75, 1.0]
+    w = [0.025, 0.25, 0.5, 0.75, 0.975]
 
     # Iterate through each chain.
     for c in chns


### PR DESCRIPTION
Fixes #75 by using the correct weights for the `quantile` function. I haven't removed this weirdness:

```julia
vals = Array(hcat([quantile(collect(skipmissing(c.value[:,i,:])), w) for i in names(c)]...)')
```

Since I'm planning on reworking most of these functions to use the newer chain summary format going on in the `dfchainsummary` branch.