### PR TITLE
Export HPD

### DIFF
--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -24,6 +24,7 @@ export Chains, getindex, setindex!, chains, setinfo, chainscat
 export describe, set_section, get_params, sections
 export sample, AbstractWeights
 export Array, DataFrame, sort_sections, convert
+export hpd
 
 # export diagnostics functions
 export discretediag, gelmandiag, gewekediag, heideldiag, rafterydiag

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -243,9 +243,6 @@ function quantile(chn::AbstractChains; q::Vector=[0.025, 0.25, 0.5, 0.75, 0.975]
     # Set showlabels bool.
     show_labels = true
 
-    # Quantile weights.
-    w = [0.025, 0.25, 0.5, 0.75, 0.975]
-
     # Iterate through each chain.
     for c in chns
         # If we're only going through one section at a time,
@@ -254,7 +251,7 @@ function quantile(chn::AbstractChains; q::Vector=[0.025, 0.25, 0.5, 0.75, 0.975]
 
         # Make labels.
         labels = map(x -> string(100 * x) * "%", q)
-        vals = Array(hcat([quantile(collect(skipmissing(c.value[:,i,:])), w) for i in names(c)]...)')
+        vals = Array(hcat([quantile(collect(skipmissing(c.value[:,i,:])), q) for i in names(c)]...)')
         new_summary = ChainSummary(round.(vals, digits=4), string.(names(c)), labels, section_name, true)
         push!(summaries, new_summary)
     end


### PR DESCRIPTION
Exports the `hpd` function we have but have never exported. Also fixes #75 for real, until #79 goes through.