### PR TITLE
Allow for pooled density plots

### DIFF
--- a/src/chains.jl
+++ b/src/chains.jl
@@ -672,3 +672,9 @@ end
 chainscat(c1::AbstractChains, args::AbstractChains...) = cat(c1, args..., dims=3)
 Base.hcat(c1::AbstractChains, args::AbstractChains...) = cat(c1, args..., dims=2)
 Base.vcat(c1::AbstractChains, args::AbstractChains...) = cat(c1, args..., dims=1)
+
+function pool_chain(c::Chains{A, T, K, L}) where {A, T, K, L}
+    val = c.value.data
+    concat = vcat([val[:,:,j] for j in 1:size(val,3)]...)
+    return Chains(cat(concat, dims=3), names(c), c.name_map; info=c.info)
+end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -23,8 +23,14 @@ const supportedplots = push!(collect(keys(translationdict)), :mixeddensity, :cor
 
 @recipe f(c::AbstractChains, s::Symbol) = c, [s]
 
-@recipe function f(c::AbstractChains, i::Int; colordim = :chain, barbounds = (0, Inf), maxlag = nothing, section = :parameters)
+@recipe function f(c::AbstractChains, i::Int;
+    colordim = :chain,
+    barbounds = (0, Inf),
+    maxlag = nothing,
+    section = :parameters,
+    append_chains = false)
     st = get(plotattributes, :seriestype, :traceplot)
+    c = append_chains ? pool_chain(c) : c
 
     if colordim == :parameter
         title --> "Chain $(chains(c)[i])"
@@ -96,8 +102,9 @@ end
 end
 
 @recipe function f(chn::MCMCChains.AbstractChains, parameters::AbstractVector{Symbol};
-        colordim = :chain, section = :parameters)
+        colordim = :chain, section = :parameters, append_chains = false)
     c = Chains(chn, section)
+    c = append_chains ? pool_chain(c) : c
     colordim != :chain && error("Symbol names are interpreted as parameter names, only compatible with `colordim = :chain`")
     ret = indexin(parameters, Symbol.(keys(c)))
     any(y -> y == nothing, ret) && error("Parameter not found")
@@ -109,9 +116,11 @@ end
                    width = 500,
                    height = 250,
                    colordim = :chain,
-                   section = :parameters
+                   section = :parameters,
+                   append_chains = false
                   )
     c = isempty(parameters) ? Chains(chn, section; sorted=true) : sort(chn)
+    c = append_chains ? pool_chain(c) : c
     ptypes = get(plotattributes, :seriestype, (:traceplot, :mixeddensity))
     ptypes = ptypes isa AbstractVector || ptypes isa Tuple ? ptypes : (ptypes,)
     @assert all(map(ptype -> ptype ∈ supportedplots, ptypes))

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -30,7 +30,7 @@ const supportedplots = push!(collect(keys(translationdict)), :mixeddensity, :cor
     section = :parameters,
     append_chains = false)
     st = get(plotattributes, :seriestype, :traceplot)
-    c = append_chains ? pool_chain(c) : c
+    c = append_chains || st == :mixeddensity ? pool_chain(c) : c
 
     if colordim == :parameter
         title --> "Chain $(chains(c)[i])"
@@ -121,7 +121,7 @@ end
                   )
     c = isempty(parameters) ? Chains(chn, section; sorted=true) : sort(chn)
     c = append_chains ? pool_chain(c) : c
-    ptypes = get(plotattributes, :seriestype, (:traceplot, :mixeddensity))
+    ptypes = get(plotattributes, :seriestype, (:traceplot, :density))
     ptypes = ptypes isa AbstractVector || ptypes isa Tuple ? ptypes : (ptypes,)
     @assert all(map(ptype -> ptype ∈ supportedplots, ptypes))
     ntypes = length(ptypes)

--- a/test/plot_test.jl
+++ b/test/plot_test.jl
@@ -23,6 +23,9 @@ chn = Chains(val)
     ps_density = density(chn, 1)
     @test isa(ps_density, Plots.Plot)
 
+    ps_density = density(chn, 1, append_chains=true)
+    @test isa(ps_density, Plots.Plot)
+
     ps_autocor = autocorplot(chn, 1)
     @test isa(ps_autocor, Plots.Plot)
 
@@ -36,6 +39,9 @@ chn = Chains(val)
 
     # plotting combinations
     ps_trace_mean = plot(chn)
+    @test isa(ps_trace_mean, Plots.Plot)
+
+    ps_trace_mean = plot(chn, append_chains=true)
     @test isa(ps_trace_mean, Plots.Plot)
 
     savefig("demo-plot.png")


### PR DESCRIPTION
Addresses #81.

`pooleddensity(chn)` (a new function) will now generate a histogram (if discrete) or a density plot (if continuous) by pooling parameters together. You can replicate this behavior with the other plotting function by calling them with the keyword `append_chains = true`.

@itsdfish does this seem reasonable to you?

Example:

```julia
using MCMCChains, StatsPlots, Distributions
d = Normal()
chn = Chains(rand(d, 5000, 2, 10))

# Regular plotting.
plot(chn)
```
![1](https://user-images.githubusercontent.com/422990/56097186-e5d3f980-5ea5-11e9-9f39-5b7102a4ca79.png)

```julia
# Append the chains together.
plot(chn, append_chains=true)
```
![2](https://user-images.githubusercontent.com/422990/56097204-0ef48a00-5ea6-11e9-9403-87ac576b86a5.png)

```julia
# Used pooleddensity
pooleddensity(chn)
```
![3](https://user-images.githubusercontent.com/422990/56097217-2cc1ef00-5ea6-11e9-96cb-f94c16616576.png)
