### PR TITLE
Describe bugfixes

### DIFF
--- a/src/chains.jl
+++ b/src/chains.jl
@@ -84,7 +84,8 @@ function Chains(val::AbstractArray{A,3},
 
     # Ensure that we have a hashedsummary key in info.
     if !in(:hashedsummary, keys(info))
-        s = (hash(0), ChainDataFrame("", DataFrame()))
+        empty_df_vec = [ChainDataFrame("", DataFrame())]
+        s = (hash(0), empty_df_vec)
         info = merge(info, (hashedsummary = Ref(s),))
     end
 
@@ -314,12 +315,12 @@ function Base.show(io::IO, c::Chains)
         if s[1] == h
             show(io, s[2])
         else
-            new_summary = summarystats(c)
+            new_summary = describe(c)
             c.info.hashedsummary.x = (h, new_summary)
             show(io, new_summary)
         end
     else
-        show(io, summarystats(c, suppress_header=true))
+        show(io, describe(c, suppress_header=true))
     end
 end
 

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -613,7 +613,8 @@ function _use_showall(c::AbstractChains, section::Symbol)
     return false
 end
 
-function _clean_sections(c::AbstractChains, sections::Vector{Symbol})
+function _clean_sections(c::AbstractChains, sections::Union{Vector{Symbol}, Symbol})
+    sections = sections isa AbstractArray ? sections : [sections]
     ks = collect(keys(c.name_map))
     return ks ∩ sections
 end

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -126,7 +126,8 @@ function describe(io::IO,
                   sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
                   args...
                  )
-    dfs = [summarystats(c, showall=showall, args...), quantile(c, showall=showall, q=q)]
+    dfs = [summarystats(c, showall=showall, sections=sections, etype=etype, args...),
+           quantile(c, showall=showall, sections=sections, q=q)]
     return dfs
 end
 
@@ -177,6 +178,7 @@ function quantile(chn::AbstractChains;
     return summarize(chn, funs...;
         func_names=func_names,
         showall=showall,
+        sections=sections,
         name = "Quantiles")
 end
 

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -13,14 +13,15 @@ ChainDataFrame(df::DataFrame) = ChainDataFrame("", df)
 
 Base.size(c::ChainDataFrame) = size(c.df)
 Base.names(c::ChainDataFrame) = names(c.df)
-
 function Base.show(io::IO, c::ChainDataFrame)
     println(io, c.name)
-    show(io, c.df, summary = false, allrows=true)
+    show(io, c.df, summary = false, allrows=true, allcols=true)
 end
 
 Base.getindex(c::ChainDataFrame, args...) = getindex(c.df, args...)
 Base.getindex(c::ChainDataFrame, s::Union{Symbol, Vector{Symbol}}) = c.df[s]
+Base.isequal(cs1::Vector{ChainDataFrame}, cs2::Vector{ChainDataFrame}) = isequal.(cs1, cs2)
+Base.isequal(c1::ChainDataFrame, c2::ChainDataFrame) = isequal(c1, c2)
 
 function Base.show(io::IO, cs::Vector{ChainDataFrame})
     println(io, summary(cs))


### PR DESCRIPTION
Addresses #87. The `quantile` function wasn't accepting the `sections` argument. I've also set it up so that the `show` function for a `Chains` object presents the results of the `describe` function, and not just `summarystats`. 

Example:

```julia
julia> chn
Object of type Chains, with data of type 1000×3×2 Array{Float64,3}

Iterations        = 1:1000
Thinning interval = 1
Chains            = 1, 2
Samples per chain = 1000
internals         = One
parameters        = Two, Three

2-element Array{ChainDataFrame,1}

Summary Statistics

│ Row │ parameters │ mean     │ std      │ naive_se   │ mcse       │ ess    │
│     │ Symbol     │ Float64  │ Float64  │ Float64    │ Float64    │ Any    │
├─────┼────────────┼──────────┼──────────┼────────────┼────────────┼────────┤
│ 1   │ Three      │ 0.503652 │ 0.290882 │ 0.00650432 │ 0.00560664 │ 2000.0 │
│ 2   │ Two        │ 0.503552 │ 0.286381 │ 0.00640367 │ 0.00607339 │ 2000.0 │

Quantiles

│ Row │ parameters │ 2.5%      │ 25.0%    │ 50.0%    │ 75.0%    │ 97.5%    │
│     │ Symbol     │ Float64   │ Float64  │ Float64  │ Float64  │ Float64  │
├─────┼────────────┼───────────┼──────────┼──────────┼──────────┼──────────┤
│ 1   │ Three      │ 0.025749  │ 0.250183 │ 0.496266 │ 0.755132 │ 0.978281 │
│ 2   │ Two        │ 0.0263851 │ 0.255008 │ 0.505298 │ 0.750213 │ 0.97352  │
```