### PR TITLE
Added mean function

### DIFF
--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -1,12 +1,13 @@
 module MCMCChains
 
+import Statistics
 import Showoff: showoff
 import StatsBase: autocor, autocov, countmap, counts, describe, predict,
        quantile, sample, sem, summarystats, sample, AbstractWeights
 import LinearAlgebra: diag
 import Serialization: serialize, deserialize
 import Base: sort, range, names, get, hash, convert, show, display
-import Statistics: cor
+import Statistics: cor, mean
 import Core.Array
 import DataFrames: DataFrame, names, eachcol
 
@@ -26,6 +27,7 @@ export sample, AbstractWeights
 export Array, DataFrame, sort_sections, convert
 export summarize, summarystats, ChainDataFrame
 export hpd, ess
+export mean
 
 # export diagnostics functions
 export discretediag, gelmandiag, gewekediag, heideldiag, rafterydiag

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -6,18 +6,44 @@
 const DEFAULT_MAP = Dict{Symbol, Vector{Any}}(:parameters => [])
 
 # Set default parameter names if not given.
-function Chains(val::AbstractArray{A,3};
+# function Chains(val::AbstractArray{A,3};
+#         start::Int=1,
+#         thin::Int=1,
+#         evidence = missing,
+#         info=NamedTuple()) where {A<:Union{Real, Union{Missing, Real}}}
+#
+#     return Chains(val, parameter_names, start=start, thin=thin)
+# end
+
+#
+function Chains(val::AbstractArray{A,1},
+        parameter_names::Vector{String} = map(i->"Param$i", 1:size(val, 2)),
+        name_map = copy(DEFAULT_MAP);
         start::Int=1,
         thin::Int=1,
         evidence = missing,
-        info=NamedTuple()) where {A<:Union{Real, Union{Missing, Real}}}
-    parameter_names = map(i->"Param$i", 1:size(val, 2))
-    return Chains(val, parameter_names, start=start, thin=thin)
+        info=NamedTuple()
+) where {A<:Union{Real, Union{Missing, Real}}}
+    Chains(val[:,:,:], parameter_names, name_map, start=start,
+           thin=thin, evidence=evidence, info=info)
+end
+
+# Set default parameter names if not given.
+function Chains(val::AbstractArray{A,2},
+        parameter_names::Vector{String} = map(i->"Param$i", 1:size(val, 2)),
+        name_map = copy(DEFAULT_MAP);
+        start::Int=1,
+        thin::Int=1,
+        evidence = missing,
+        info=NamedTuple()
+) where {A<:Union{Real, Union{Missing, Real}}}
+    Chains(val[:,:,:], parameter_names, name_map, start=start,
+           thin=thin, evidence=evidence, info=info)
 end
 
 # Generic chain constructor.
 function Chains(val::AbstractArray{A,3},
-        parameter_names::Vector{String},
+        parameter_names::Vector{String} = map(i->"Param$i", 1:size(val, 2)),
         name_map = copy(DEFAULT_MAP);
         start::Int=1,
         thin::Int=1,

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -413,3 +413,59 @@ function summarystats(chn::MCMCChains.AbstractChains;
 
     return summary_df
 end
+
+"""
+    mean(chn::MCMCChains.AbstractChains;
+            append_chains::Bool=true,
+            showall::Bool=false,
+            sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
+            digits=missing,
+            args...)
+    mean(chn::MCMCChains.AbstractChains, ss::Vector{Symbol})
+    mean(chn::MCMCChains.AbstractChains, s::Symbol)
+    mean(chn::MCMCChains.AbstractChains, s::String)
+    mean(chn::MCMCChains.AbstractChains, ss::Vector{String})
+
+Calculates the mean of a `Chains` object, or a specific parameter.
+"""
+function Statistics.mean(chn::MCMCChains.AbstractChains;
+        append_chains::Bool=true,
+        showall::Bool=false,
+        sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
+        digits=missing,
+        args...
+    )
+    # Store everything.
+    funs = [mean∘cskip]
+    func_names = [:mean]
+
+    # Summarize.
+    summary_df = summarize(chn, funs...;
+        sections=sections,
+        func_names=func_names,
+        showall=showall,
+        name="Mean",
+        digits=digits)
+
+    return summary_df
+end
+
+Statistics.mean(chn::MCMCChains.AbstractChains, ss::Vector{Symbol}) =
+    mean(chn[:, ss, :])
+Statistics.mean(chn::MCMCChains.AbstractChains, s::String) =
+    mean(chn, Symbol(s))
+Statistics.mean(chn::MCMCChains.AbstractChains, ss::Vector{String}) =
+    mean(chn, Symbol.(ss))
+function Statistics.mean(chn::MCMCChains.AbstractChains, s::Symbol)
+    syms = _sym2index(chn, [s])
+
+    if length(syms) == 0
+        throw(ArgumentError("Symbol :$s not found in chain."))
+    end
+
+    if length(syms) > 1
+        return mean(chn[:, syms, :])
+    else
+        return mean(chn[:,syms,:].value.data)
+    end
+end

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -35,6 +35,10 @@ chn_disc = Chains(val_disc, start = 1, thin = 2)
     @test all(MCMCChains.indiscretesupport(chn) .== [false, false, false, true])
     @test setinfo(chn, NamedTuple{(:A, :B)}((1,2))).info == NamedTuple{(:A, :B)}((1,2))
     @test isa(set_section(chn, Dict(:internals => ["Param1"])), MCMCChains.AbstractChains)
+    @test mean(chn) isa MCMCChains.ChainDataFrame
+    @test mean(chn, ["Param1", "Param2"]) isa MCMCChains.ChainDataFrame
+    @test 1.05 >= mean(chn, :Param1) >= 0.95
+    @test 1.05 >= mean(chn, "Param1") >= 0.95
 end
 
 @testset "function tests" begin


### PR DESCRIPTION
Allows you to do stuff like

```julia
# Returns a dataframe with just parameters and their means.
mean(chn)

# Returns either a dataframe (if more than one parameter)
# or a single value.
mean(chn, :x)

# Returns a dataframe.
mean(chn, [:x, :y])
```

The above also works with `Strings`. I've also made a redundant `Chains` constructor a little more helpful by converting a 2d array to a 3d one, so you don't have to make an AxisArray or a 3d array yourself if you're passing in custom values.