### PR TITLE
Add name change function

### DIFF
--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -22,7 +22,7 @@ using AxisArrays
 const axes = Base.axes
 
 export Chains, getindex, setindex!, chains, setinfo, chainscat
-export describe, set_section, get_params, sections
+export describe, set_section, get_params, sections, set_names
 export sample, AbstractWeights
 export Array, DataFrame, sort_sections, convert
 export summarize, summarystats, ChainDataFrame

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -39,6 +39,8 @@ chn_disc = Chains(val_disc, start = 1, thin = 2)
     @test mean(chn, ["Param1", "Param2"]) isa MCMCChains.ChainDataFrame
     @test 1.05 >= mean(chn, :Param1) >= 0.95
     @test 1.05 >= mean(chn, "Param1") >= 0.95
+    @test names(set_names(chn, Dict("Param1" => "PARAM1"))) ==
+        ["PARAM1", "Param2", "Param3", "Param4"]
 end
 
 @testset "function tests" begin


### PR DESCRIPTION
Addresses #116 by adding the function `set_names`, which accepts a `Chain` and a `Dict` and returns a new chain with the names replaced. Usage example:

```julia
using MCMCChains

chn = Chains(
	rand(100, 5, 5), 
	["one", "two", "three", "four", "five"], 
	Dict(:internals => ["four", "five"])
)

# Set "one" and "five" to uppercase.
set_names(chn,  Dict(["one" => "ONE", "five" => "FIVE"]))
```

This returns a new chain, like the following:

```julia
Object of type Chains, with data of type 100×5×5 Array{Float64,3}

Iterations        = 1:100
Thinning interval = 1
Chains            = 1, 2, 3, 4, 5
Samples per chain = 100
internals         = four, FIVE
parameters        = two, ONE, three

2-element Array{ChainDataFrame,1}

Summary Statistics

│ Row │ parameters │ mean     │ std      │ naive_se  │ mcse       │ ess     │ r_hat    │
│     │ Symbol     │ Float64  │ Float64  │ Float64   │ Float64    │ Any     │ Any      │
├─────┼────────────┼──────────┼──────────┼───────────┼────────────┼─────────┼──────────┤
│ 1   │ ONE        │ 0.482785 │ 0.28335  │ 0.0126718 │ 0.00959775 │ 500.0   │ 0.995402 │
│ 2   │ three      │ 0.513408 │ 0.286564 │ 0.0128156 │ 0.0113533  │ 423.697 │ 1.00125  │
│ 3   │ two        │ 0.499074 │ 0.295281 │ 0.0132054 │ 0.0168991  │ 448.112 │ 1.00192  │

Quantiles

│ Row │ parameters │ 2.5%      │ 25.0%    │ 50.0%    │ 75.0%    │ 97.5%    │
│     │ Symbol     │ Float64   │ Float64  │ Float64  │ Float64  │ Float64  │
├─────┼────────────┼───────────┼──────────┼──────────┼──────────┼──────────┤
│ 1   │ ONE        │ 0.0273963 │ 0.209799 │ 0.498201 │ 0.714741 │ 0.951088 │
│ 2   │ three      │ 0.0276404 │ 0.25914  │ 0.511508 │ 0.744568 │ 0.976089 │
│ 3   │ two        │ 0.0286226 │ 0.245631 │ 0.499897 │ 0.757661 │ 0.975526 │
```