### PR TITLE
Allow users to disable sorting

### DIFF
--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -22,7 +22,7 @@ using AxisArrays
 const axes = Base.axes
 
 export Chains, getindex, setindex!, chains, setinfo, chainscat
-export describe, set_section, get_params, sections
+export describe, set_section, get_params, sections, set_names
 export sample, AbstractWeights
 export Array, DataFrame, sort_sections, convert
 export summarize, summarystats, ChainDataFrame

--- a/src/discretediag.jl
+++ b/src/discretediag.jl
@@ -373,10 +373,11 @@ function discretediag(chn::AbstractChains; frac::Real=0.3,
                       method::Symbol=:weiss,
                       sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
                       nsim::Int=1000,
-                      showall=false)
+                      showall=false,
+                      sorted=true)
     c = showall ?
-        sort(chn) :
-        Chains(chn, _clean_sections(chn, sections); sorted=true)
+        sorted ? sort(chn) : chn :
+        Chains(chn, _clean_sections(chn, sections); sorted=sorted)
 
     @assert !any(ismissing.(c.value)) "Diagnostic doesn't support missing values"
 

--- a/src/gelmandiag.jl
+++ b/src/gelmandiag.jl
@@ -5,10 +5,11 @@ function gelmandiag(chn::AbstractChains;
         mpsrf::Bool=false,
         transform::Bool=false,
         sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-        showall=false)
+        showall=false,
+        sorted=true)
     c = showall ?
-        sort(chn) :
-        Chains(chn, _clean_sections(chn, sections); sorted=true)
+        sorted ? sort(chn) : chn :
+        Chains(chn, _clean_sections(chn, sections); sorted=sorted)
     @assert !any(ismissing.(c.value)) "Gelman diagnostics doesn't support missing values"
 
     n, p, m = size(c.value)

--- a/src/gewekediag.jl
+++ b/src/gewekediag.jl
@@ -20,10 +20,12 @@ end
 function gewekediag(chn::AbstractChains; first::Real=0.1, last::Real=0.5,
                     etype=:imse,
                     sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-                    showall=false, args...)
+                    showall=false,
+                    sorted=true, 
+                    args...)
     c = showall ?
-        sort(chn) :
-        Chains(chn, _clean_sections(chn, sections); sorted=true)
+        sorted ? sort(chn) : chn :
+        Chains(chn, _clean_sections(chn, sections); sorted=sorted)
 
     _, p, m = size(c.value)
     diags = [vals = Array{Float64}(undef, p, 2) for _ in 1:m]

--- a/src/heideldiag.jl
+++ b/src/heideldiag.jl
@@ -32,11 +32,12 @@ function heideldiag(chn::AbstractChains;
                     etype = :imse,
                     sections::Vector{Symbol}=[:parameters],
                     showall=false,
+                    sorted=true,
                     args...
                    )
     c = showall ?
-       sort(chn) :
-       Chains(chn, _clean_sections(chn, sections); sorted=true)
+       sorted ? sort(chn) : chn :
+       Chains(chn, _clean_sections(chn, sections); sorted=sorted)
 
     # Preallocate.
     _, p, m = size(c.value)

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -106,8 +106,8 @@ end
 end
 
 @recipe function f(chn::MCMCChains.AbstractChains, parameters::AbstractVector{Symbol};
-        colordim = :chain, section = :parameters, append_chains = false)
-    c = Chains(chn, section)
+        colordim = :chain, section = :parameters, append_chains = false, sorted=true)
+    c = Chains(chn, section, sorted=sorted)
     c = append_chains ? pool_chain(c) : c
     colordim != :chain && error("Symbol names are interpreted as parameter names, only compatible with `colordim = :chain`")
     ret = indexin(parameters, Symbol.(keys(c)))
@@ -121,9 +121,12 @@ end
                    height = 250,
                    colordim = :chain,
                    section = :parameters,
-                   append_chains = false
+                   append_chains = false,
+                   sorted=true
                   )
-    c = isempty(parameters) ? Chains(chn, section; sorted=true) : sort(chn)
+    c = isempty(parameters) ? 
+        Chains(chn, section; sorted=sorted) : 
+        sorted ? sort(chn) : chn
     c = append_chains ? pool_chain(c) : c
     ptypes = get(plotattributes, :seriestype, (:traceplot, :mixeddensity))
     ptypes = ptypes isa AbstractVector || ptypes isa Tuple ? ptypes : (ptypes,)

--- a/src/rafterydiag.jl
+++ b/src/rafterydiag.jl
@@ -58,11 +58,12 @@ function rafterydiag(
                      s = 0.95,
                      eps = 0.001,
                      showall=false,
+                     sorted=true,
                      sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters]
                     )
     c = showall ?
-        sort(chn) :
-        Chains(chn, _clean_sections(chn, sections); sorted=true)
+        sorted ? sort(chn) : chn :
+        Chains(chn, _clean_sections(chn, sections); sorted=sorted)
     _, p, m = size(c.value)
     vals = [Array{Float64}(undef, p, 5) for i in 1:m]
     for j in 1:p, k in 1:m

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -39,6 +39,8 @@ chn_disc = Chains(val_disc, start = 1, thin = 2)
     @test mean(chn, ["Param1", "Param2"]) isa MCMCChains.ChainDataFrame
     @test 1.05 >= mean(chn, :Param1) >= 0.95
     @test 1.05 >= mean(chn, "Param1") >= 0.95
+    @test names(set_names(chn, Dict("Param1" => "PARAM1"))) ==
+        ["PARAM1", "Param2", "Param3", "Param4"]
 end
 
 @testset "function tests" begin

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -56,6 +56,14 @@ end
     @test isa(rafterydiag(chn[:,1,:]), Vector{MCMCChains.ChainDataFrame})
 end
 
+@testset "sorting" begin
+    chn_sorted = Chains(rand(100,3,1), ["2", "1", "3"])
+    chn_unsorted = Chains(rand(100,3,1), ["2", "1", "3"], sorted=false)
+
+    @test names(chn_sorted) == ["1", "2", "3"]
+    @test names(chn_unsorted) == ["2", "1", "3"]
+end
+
 @testset "concatenation tests" begin
     v1 = rand(500, 5, 1)
     v2 = rand(500, 5, 1)


### PR DESCRIPTION
Addresses #110. Users can now pass in the `sorted=false` keyword argument to `Chains` constructors, which prevents them from being sorted. This is the important one -- the current default is to sort all the parameters when they are constructed. 

You can also pass `sorted=false` to all the plotting and summary functions (`plot(chain, sorted=false)`) which is more cosmetic.