### PR TITLE
Fix IJulia display error

### DIFF
--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -87,6 +87,7 @@ end
 
 Base.lastindex(c::ChainDataFrame, i::Integer) = lastindex(c.df, i)
 
+Base.convert(::Type{Array{ChainDataFrame,1}}, cs::Array{ChainDataFrame,1}) = cs
 function Base.convert(::Type{T}, cs::Array{ChainDataFrame,1}) where T<:Array
     arrs = [convert(T, cs[j].df[:, 2:end]) for j in 1:length(cs)]
     return cat(arrs..., dims = 3)


### PR DESCRIPTION
Addresses #117. The issue appears to have been a case where IJulia was trying to convert a `Vector{ChainDataFrame}` to a `Vector{ChainDataFrame}`, but there was no function to handle this. I added a corner-case function and it seems to work fine on my build.