### PR TITLE
Fixed sorting for display functions

### DIFF
--- a/src/chains.jl
+++ b/src/chains.jl
@@ -13,7 +13,8 @@ function Chains(
         start::Int=1,
         thin::Int=1,
         evidence = missing,
-        info::NamedTuple=NamedTuple()
+        info::NamedTuple=NamedTuple(),
+        sorted::Bool=true
 ) where {A<:Union{Real, Union{Missing, Real}}}
 	return Chains(Array(hcat(val...)'), parameter_names, name_map, start=start,
            thin=thin, evidence=evidence, info=info)
@@ -584,8 +585,16 @@ function sort(c::Chains{A, T, K, L}) where {A, T, K, L}
     for i in eachindex(sorted)
         new_v[:, i, :] = v[:, sorted[i][1], :]
     end
+
+    # Sort the name map too:
+    name_dict = Dict()
+    for (name, values) in pairs(c.name_map)
+        name_dict[name] = sort(values, by=x -> string(x), lt=MCMCChains.natural)
+    end
+    new_name_map = _dict2namedtuple(name_dict)
+
     aa = AxisArray(new_v, new_axes...)
-    return MCMCChains.Chains{A, T, K, L}(aa, c.logevidence, c.name_map, c.info)
+    return MCMCChains.Chains{A, T, K, L}(aa, c.logevidence, new_name_map, c.info)
 end
 
 """

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -63,7 +63,8 @@ function Array(chn::MCMCChains.AbstractChains,
         sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters];
         append_chains=true,
         remove_missing_union=true,
-        showall=false
+        showall=false,
+        sorted=false
     )
     sections = _clean_sections(chn, sections)
     sections = sections isa AbstractArray ? sections : [sections]
@@ -178,7 +179,7 @@ function DataFrame(chn::MCMCChains.AbstractChains,
     sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters];
     append_chains=true,
     remove_missing_union=true,
-    sorted=true,
+    sorted=false,
     showall=false)
     sections = _clean_sections(chn, sections)
     sections = sections isa AbstractArray ? sections : [sections]

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -386,6 +386,7 @@ function summarystats(chn::MCMCChains.AbstractChains;
         sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
         etype=:bm,
         digits=missing,
+        sorted=false,
         args...
     )
 


### PR DESCRIPTION
Some additional clean-up and bug fixing for #110. The `name_map` wasn't being sorted when `sort(chain)` was called, which lead to cases where the chain was not sorted but the output was.