### PR TITLE
Don't merge variables that are substrings

### DIFF
--- a/src/chains.jl
+++ b/src/chains.jl
@@ -203,7 +203,7 @@ function _sym2index(c::Chains, v::Union{Vector{Symbol}, Vector{String}}; sorted:
         value = v_str[i]
         if idx[i] == nothing
             append!(syms,
-                collect(Iterators.filter(k -> occursin(value*"[", string(k)), names(c))))
+                collect(Iterators.filter(k -> startswith(value*"[", string(k)), names(c))))
         else
             push!(syms, value)
         end

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -203,7 +203,7 @@ function _sym2index(c::Chains, v::Union{Vector{Symbol}, Vector{String}}; sorted:
         value = v_str[i]
         if idx[i] == nothing
             append!(syms,
-                collect(Iterators.filter(k -> startswith(value*"[", string(k)), names(c))))
+                collect(Iterators.filter(k -> startswith(string(k), value*"["), names(c))))
         else
             push!(syms, value)
         end


### PR DESCRIPTION
This fixes a bug where multivariate variables that were substrings of another were combined. For example, if a variable `theta[1]` and a variable `eta[1]` were in the `Chains`, then calling `get` with `flatten=false` would give an `eta` with both the values of `eta` and of `theta`.