### PR TITLE
Fix chain concatenation.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = " Chain types and utility functions for MCMC simulations."
-version = "0.3.14"
+version = "0.3.15"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -684,8 +684,6 @@ end
 function cat1(c1::AbstractChains, args::AbstractChains...)
     rng = range(c1)
     for c in args
-        last(rng) + step(rng) == first(c) ||
-            throw(ArgumentError("noncontiguous chain iterations"))
         step(rng) == step(c) ||
             throw(ArgumentError("chain thinning differs"))
         rng = first(rng):step(rng):last(c)
@@ -701,7 +699,7 @@ function cat1(c1::AbstractChains, args::AbstractChains...)
 
     name_map = _ntdictmerge(c1.name_map, map(c -> c.name_map, args)...)
 
-    value = cat(c1.value, map(c -> c.value, args)..., dims=1)
+    value = cat(c1[names(c1)].value.data, map(c -> c[names(c1)].value.data, args)..., dims=1)
     Chains(value, nms, name_map, start=first(rng), thin=step(rng),
         info = c1.info)
 end


### PR DESCRIPTION
`vcat(chain1, chain2)` often did not do what you wanted it to, which is unquestioningly stick the samples of `chain2` on the bottom of the samples of `chain1`. I've made it actually possible to use `vcat` under normal circumstances.