### PR TITLE
Use reduce instead of splatting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,8 +20,6 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-julia = "^1"
-Turing = "^0.7"
 AxisArrays = "^0.3"
 DataFrames = "^0.19"
 Distributions = "^0.21"
@@ -30,7 +28,8 @@ RecipesBase = "^0.7"
 Showoff = "^0.3"
 SpecialFunctions = "^0.8"
 StatsBase = "^0.32"
-
+Turing = "^0.7"
+julia = "^1"
 
 [extras]
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -16,7 +16,7 @@ function Chains(
         info::NamedTuple=NamedTuple(),
         sorted::Bool=true
 ) where {A<:Union{Real, Union{Missing, Real}}}
-	return Chains(Array(hcat(val...)'), parameter_names, name_map, start=start,
+	return Chains(copy(reduce(hcat, val)'), parameter_names, name_map, start=start,
            thin=thin, evidence=evidence, info=info)
 end
 
@@ -137,7 +137,7 @@ function Chains(
             Chains{A, typeof(evidence), typeof(name_map_tupl), typeof(info)}(
                 arr, evidence, name_map_tupl, info)
         )
-    else 
+    else
         return Chains{A, typeof(evidence), typeof(name_map_tupl), typeof(info)}(
                 arr, evidence, name_map_tupl, info)
     end

--- a/src/discretediag.jl
+++ b/src/discretediag.jl
@@ -283,8 +283,7 @@ function diag_all(X::AbstractMatrix{U}, method::Symbol,
         stat = t * sum(chi_stat)
         bstats = zeros(Float64, nsim)
         for b in 1:nsim
-          Y = hcat([simulate_NDARMA(t, 1, 0, phat, [phia, 1-phia])
-                for j in 1:d]...)
+          Y = reduce(hcat, [simulate_NDARMA(t, 1, 0, phat, [phia, 1-phia]) for j in 1:d])
           s = hangartner_inner(Y, m)[1]
           bstats[b] = s
         end
@@ -294,7 +293,7 @@ function diag_all(X::AbstractMatrix{U}, method::Symbol,
       elseif method == :MCBOOT
         bstats = zeros(Float64, nsim)
         for b in 1:nsim
-          Y = hcat([simulate_MC(t, mP) for j in 1:d]...)
+          Y = reduce(hcat, [simulate_MC(t, mP) for j in 1:d])
           s = hangartner_inner(Y, m)[1]
           bstats[b] = s
         end
@@ -311,7 +310,7 @@ function diag_all(X::AbstractMatrix{U}, method::Symbol,
         stat = hot_stat
         bstats = zeros(Float64, nsim)
         for b in 1:nsim
-          Y = hcat([simulate_MC(t, mP) for j in 1:d]...)
+          Y = reduce(hcat, [simulate_MC(t, mP) for j in 1:d])
           (s,sd) = bd_inner(Y, m)[1:2]
           bstats[b] = s/sd
         end


### PR DESCRIPTION
For stacking vectors `v` of vectors or matrices, `reduce(hcat, v)` is usually more efficient than `hcat(v...)`, due to the optimized implementation in https://github.com/JuliaLang/julia/blob/89a51fb98485219680c7106e94cf75fd8069f3f8/base/abstractarray.jl#L1375-L1379 (see also the discussion in https://github.com/JuliaLang/julia/issues/21672).

A simple benchmark demonstrates the performance increase with `reduce`:
```julia
using BenchmarkTools

f(x) =  Array(hcat(v...)')
g(x) = copy(reduce(hcat, x)')

u = [rand(128) for i in 1:1000]
@btime f($u)        # 506.439 μs (9 allocations: 1.95 MiB)
@btime g($u)        # 365.840 μs (4 allocations: 1.95 MiB)

v = [rand(1000) for i in 1:128]
@btime f($v)        # 529.852 μs (9 allocations: 1.95 MiB)
@btime g($v)        # 272.787 μs (4 allocations: 1.95 MiB)
```

BTW, the possibly more idiomatic implementation with `mapreduce` is terribly slow:
```julia
h(x) = mapreduce(transpose, vcat, x)

@btime h($u)        # 91.605 ms (3982 allocations: 488.89 MiB)
@btime h($v)        # 11.339 ms (508 allocations: 63.00 MiB)                           
```