### PR TITLE
Fix test of `resume`

### DIFF
--- a/test/serialization_tests.jl
+++ b/test/serialization_tests.jl
@@ -30,8 +30,8 @@ ProjDir = mktempdir()
         open(f->read(f, String), joinpath(ProjDir, "chn2.txt"))
 
     # Test whether sampler state made it through serialization/deserialization.
-    chn3 = Turing.Utilities.resume(chn2, 100)
-    @test range(chn3) == 1:1:600
+    chn3 = Turing.Inference.resume(chn2, 100)
+    @test range(chn3) == 1:1:100
 end
 
 rm(ProjDir, force=true, recursive=true)


### PR DESCRIPTION
Not sure if it this PR should be merged, since `resume` will be exported and its behaviour will change once https://github.com/TuringLang/Turing.jl/pull/954 is merged. Nevertheless, IMO it's problematic that currently due to this test error none of the subsequent tests are run, which makes it impossible to ensure that new PRs such as https://github.com/TuringLang/MCMCChains.jl/pull/145 do not introduce any new test failures.