### PR TITLE
Use permutedims

### DIFF
--- a/src/chains.jl
+++ b/src/chains.jl
@@ -137,7 +137,7 @@ function Chains(
             Chains{A, typeof(evidence), typeof(name_map_tupl), typeof(info)}(
                 arr, evidence, name_map_tupl, info)
         )
-    else 
+    else
         return Chains{A, typeof(evidence), typeof(name_map_tupl), typeof(info)}(
                 arr, evidence, name_map_tupl, info)
     end
@@ -747,10 +747,10 @@ chainscat(c1::AbstractChains, args::AbstractChains...) = cat(c1, args..., dims=3
 Base.hcat(c1::AbstractChains, args::AbstractChains...) = cat(c1, args..., dims=2)
 Base.vcat(c1::AbstractChains, args::AbstractChains...) = cat(c1, args..., dims=1)
 
-function pool_chain(c::Chains{A, T, K, L}) where {A, T, K, L}
-    val = c.value.data
-    concat = vcat([val[:,:,j] for j in 1:size(val,3)]...)
-    return Chains(cat(concat, dims=3), names(c), c.name_map; info=c.info)
+function pool_chain(c::Chains)
+    data = c.value.data
+    pool_data = reshape(permutedims(data, [1, 3, 2]), :, size(data, 2), 1)
+    return Chains(pool_data, names(c), c.name_map; info=c.info)
 end
 
 function set_names(c::Chains{A, T, K, L}, d::Dict; sorted::Bool=true) where {A, T, K, L}


### PR DESCRIPTION
Another performance improvement, according to the following benchmark:
```julia
using BenchmarkTools

f(x) = cat(vcat([x[:, :, j] for j in 1:size(x, 3)]...), dims=3)
g(x) = reshape(permutedims(x, [1, 3, 2]), :, size(x, 2), 1)

a = rand(1000, 5, 10)
@btime f($a) # 162.962 μs (42 allocations: 1.15 MiB)
@btime g($a) # 43.850 μs (9 allocations: 391.17 KiB)

b = rand(1000, 100, 100);
@btime f($b) # 157.489 ms (226 allocations: 228.89 MiB)
@btime g($b) # 36.954 ms (9 allocations: 76.29 MiB)