### PR TITLE
Remove chain sorting by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = " Chain types and utility functions for MCMC simulations."
-version = "0.4.1"
+version = "1.0.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -26,7 +26,7 @@ function Chains(
         thin::Int=1,
         evidence = missing,
         info::NamedTuple=NamedTuple(),
-        sorted::Bool=true)
+        sorted::Bool=false)
     # If we received an array of pairs, convert it to a dictionary.
     name_map = if typeof(name_map_original) <: Dict
         # Copying can avoid state mutation.
@@ -143,7 +143,7 @@ end
 
 
 #################### Indexing ####################
-function _sym2index(c::Chains, v::Union{Vector{Symbol}, Vector{String}}; sorted::Bool = true)
+function _sym2index(c::Chains, v::Union{Vector{Symbol}, Vector{String}}; sorted::Bool = false)
     v_str = string.(v)
     idx = indexin(v_str, names(c))
     syms = []

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -12,11 +12,11 @@ val = randn(n_iter, n_name, n_chain) .+ [1, 2, 3]'
 val = hcat(val, rand(1:2, n_iter, 1, n_chain))
 
 # construct a Chains object
-chn = Chains(val, start = 1, thin = 2)
+chn = Chains(val, start = 1, thin = 2, sorted=true)
 
 # Chains object for discretediag
 val_disc = rand(Int16, 200, n_name, n_chain)
-chn_disc = Chains(val_disc, start = 1, thin = 2)
+chn_disc = Chains(val_disc, start = 1, thin = 2, sorted=true)
 
 @testset "basic chains functions" begin
     @test first(chn) == 1
@@ -67,7 +67,7 @@ end
 end
 
 @testset "sorting" begin
-    chn_sorted = Chains(rand(100,3,1), ["2", "1", "3"])
+    chn_sorted = Chains(rand(100,3,1), ["2", "1", "3"], sorted=true)
     chn_unsorted = Chains(rand(100,3,1), ["2", "1", "3"], sorted=false)
 
     @test names(chn_sorted) == ["1", "2", "3"]

--- a/test/summarize_tests.jl
+++ b/test/summarize_tests.jl
@@ -5,7 +5,8 @@ using MCMCChains, Test
     val = rand(1000, 8, 4)
     chns = Chains(val,
                 ["a", "b", "c", "d", "e", "f", "g", "h"],
-                Dict(:internals => ["c", "d", "e", "f", "g", "h"]))
+                Dict(:internals => ["c", "d", "e", "f", "g", "h"]),
+                sorted=true)
 
 
     parm_df = summarize(chns, sections=[:parameters])


### PR DESCRIPTION
This PR makes it so that chain parameters are no longer sorted by default -- any packages that relied on MCMCChains using natural sort order will need to pass `sorted=true` in their `Chains` call in order to keep current behavior.

As per @goedman's suggestion, I have also incremented the version number to 1.0 since MCMCChains is relatively stable at this point.