### PR TITLE
Fixes sorting bug

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = " Chain types and utility functions for MCMC simulations."
-version = "3.0.0"
+version = "3.0.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -159,6 +159,7 @@ function describe(io::IO,
                   showall::Bool=false,
                   sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
                   digits::Int=4,
+                  sorted=false,
                   args...
                  )
     dfs = vcat(summarystats(c,
@@ -166,12 +167,14 @@ function describe(io::IO,
                 sections=sections,
                 etype=etype,
                 digits=digits,
+                sorted=sorted,
                 args...),
            quantile(c,
                 showall=showall,
                 sections=sections,
                 q=q,
-                digits=digits))
+                digits=digits,
+                sorted=sorted))
     return dfs
 end
 

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -223,7 +223,8 @@ function quantile(chn::Chains;
         append_chains=true,
         showall=false,
         sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-        digits::Int=4)
+        digits::Int=4,
+        sorted=false)
     # compute quantiles
     funs = Function[]
     func_names = String[]
@@ -231,12 +232,15 @@ function quantile(chn::Chains;
         push!(funs, x -> quantile(cskip(x), i))
         push!(func_names, "$(string(100*i))%")
     end
+
     return summarize(chn, funs...;
+        sections=sections,
         func_names=func_names,
         showall=showall,
-        sections=sections,
-        name = "Quantiles",
-        digits=digits)
+        name="Quantiles",
+        digits=digits,
+        append_chains=append_chains, 
+        sorted=sorted)
 end
 
 """
@@ -257,7 +261,8 @@ function ess(chn::Chains;
     showall=false,
     sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
     maxlag = 250,
-    digits::Int=4
+    digits::Int=4,
+    sorted=false
 )
 	param = showall ? names(chn) : names(chn, sections)
 	n_chain_orig = size(chn, 3)
@@ -401,7 +406,7 @@ function summarystats(chn::Chains;
     func_names = [:mean, :std, :naive_se, :mcse]
 
     # Caluclate ESS separately.
-    ess_df = ess(chn, sections=sections, showall=showall)
+    ess_df = ess(chn, sections=sections, showall=showall, sorted=sorted)
 
     # Summarize.
     summary_df = summarize(chn, funs...;

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -269,10 +269,9 @@ function summarize(chn::Chains, funs...;
 
     if additional_df != nothing
         if append_chains
-            ret_df = merge(ret_df, additional_df.nt)
-            # ret_df = join(ret_df, additional_df, on=:parameters)
+            ret_df = merge_cdf(ret_df, additional_df.nt)
         else
-            ret_df = [merge(r, additional_df.nt) for r in ret_df]
+            ret_df = [merge_cdf(r, additional_df.nt) for r in ret_df]
         end
     end
 
@@ -287,4 +286,32 @@ end
 function handle_funs(fns)
     tmp =  [string(f) for f in fns]
     Symbol.([split(tmp[i], ".")[end] for i in 1:length(tmp)])
+end
+
+"""
+Collects the keys of a named tuple and maintains parameter name ordering. Used
+when an additional namedtuple is passed to `summarize` to be joined.
+"""
+function merge_cdf(n1::NamedTuple, n2::NamedTuple)
+    ks1 = collect(keys(n1))
+    ks2 = collect(keys(n2))
+    ks = tuple(unique(vcat(ks1, ks2))...)
+    if :parameters in ks1 && :parameters in ks2
+        p1 = Symbol.(n1.parameters)
+        p2 = Symbol.(n2.parameters)
+        inds = indexin(p1, p2)
+
+        vals = []
+        for k in ks
+            if k in ks1
+                push!(vals, n1[k])
+            else
+                push!(vals, n2[k][inds])
+            end
+        end
+
+        return NamedTuple{ks}(tuple(vals...))
+    else 
+        return merge(n1, n2)
+    end
 end

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -128,7 +128,7 @@ function Base.getindex(
 )
     s = s isa AbstractArray ? s : [s]
     ks = ks isa AbstractArray ? ks : [ks]
-    ind = indexin(s, c.nt[:parameters])
+    ind = indexin(Symbol.(s), Symbol.(c.nt[:parameters]))
 
     not_found = map(x -> x === nothing, ind)
 

--- a/test/summarize_tests.jl
+++ b/test/summarize_tests.jl
@@ -15,7 +15,7 @@ using Statistics: std
     @test names(parm_df) == [:parameters, :mean, :std, :naive_se, :mcse, :ess, :r_hat]
 
     all_sections_df = summarize(chns, sections=[:parameters, :internals])
-    @test all_sections_df[:,:parameters] == [:a, :b, :c, :d, :e, :f, :g, :h]
+    @test all_sections_df[:,:parameters] == ["a", "b", "c", "d", "e", "f", "g", "h"]
     @test size(all_sections_df) == (8, 7)
 
     two_parms_two_funs_df = summarize(chns[[:a, :b]], mean, std)


### PR DESCRIPTION
Fixes https://github.com/TuringLang/Turing.jl/issues/1132, which was caused by the new display method blindly merging `NamedTuples` without preserving row ordering. It's a minor fix, so I'll merge it once tests pass.