### PR TITLE
Add DataFrame(::ChainDataFrame) constructor

### DIFF
--- a/src/dataframes-compat.jl
+++ b/src/dataframes-compat.jl
@@ -102,3 +102,11 @@ function DataFrames.DataFrame(chn::Chains,
     end
     return b
 end
+
+DataFrames.DataFrame(cdfs::Vector{<:ChainDataFrame}) = map(DataFrame, cdfs)
+function DataFrames.DataFrame(cdf::ChainDataFrame)
+    colnames = collect(keys(cdf.nt))
+    cols = collect(values(cdf.nt))
+
+    return DataFrame(cols, colnames)
+end

--- a/test/dfconstructor_tests.jl
+++ b/test/dfconstructor_tests.jl
@@ -39,3 +39,16 @@ using DataFrames
     @test size(df8) == (4, )
     @test size(df8[1]) == (1000, 8)
 end
+@testset "ChainDataFrame converter" begin
+    val = rand(1000, 5, 4)
+    chain = Chains(val)
+
+    cdfs = describe(chain)
+
+    dfs = DataFrame(cdfs)
+    df1 = DataFrame(cdfs[1])
+    df2 = DataFrame(cdfs[2])
+
+    @test dfs[1] == df1
+    @test dfs[2] == df2
+end


### PR DESCRIPTION
Allows you to convert a `ChainDataFrame` to a `DataFrame` if you have `DataFrames` loaded. 

```julia
val = rand(1000, 5, 4)
chain = Chains(val)

cdfs = describe(chain)

dfs = DataFrame(cdfs)
df1 = DataFrame(cdfs[1])
df2 = DataFrame(cdfs[2])
```