### PR TITLE
Add `concretize` and fix https://github.com/TuringLang/MCMCChains.jl/issues/189

### DIFF
--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -39,11 +39,11 @@ Parameters:
 - `info` : A `NamedTuple` containing miscellaneous information relevant to the chain.
 The `info` field can be set using `setinfo(c::Chains, n::NamedTuple)`.
 """
-struct Chains{A, T, K<:NamedTuple, L<:NamedTuple} <: AbstractMCMC.AbstractChains
-    value::AxisArray{A,3}
-    logevidence::T
+struct Chains{T,V<:AxisArray{T,3},L,K<:NamedTuple,I<:NamedTuple} <: AbstractMCMC.AbstractChains
+    value::V
+    logevidence::L
     name_map::K
-    info::L
+    info::I
 end
 
 include("utils.jl")

--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -39,8 +39,8 @@ Parameters:
 - `info` : A `NamedTuple` containing miscellaneous information relevant to the chain.
 The `info` field can be set using `setinfo(c::Chains, n::NamedTuple)`.
 """
-struct Chains{T,V<:AxisArray{T,3},L,K<:NamedTuple,I<:NamedTuple} <: AbstractMCMC.AbstractChains
-    value::V
+struct Chains{T,L,K<:NamedTuple,I<:NamedTuple} <: AbstractMCMC.AbstractChains
+    value::AxisArray{T,3}
     logevidence::L
     name_map::K
     info::I

--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -21,7 +21,7 @@ import Statistics: std, cor, mean, var
 export Chains, chains, chainscat
 export set_section, get_params, sections, sort_sections, setinfo, set_names
 export autocor, describe, sample, summarystats, AbstractWeights, mean, quantile
-export ChainDataFrame, DataFrame
+export ChainDataFrame
 export summarize
 
 # Export diagnostics functions

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -86,14 +86,13 @@ function Chains(
                     var = parameter_names,
                     chain = 1:size(val, 3))
 
+    # Create the new chain.
+    chains = Chains(arr, evidence, name_map_tupl, info)
+
     if sorted
-        return sort(
-            Chains{eltype(val), typeof(evidence), typeof(name_map_tupl), typeof(info)}(
-                arr, evidence, name_map_tupl, info)
-        )
+        return sort(chains)
     else
-        return Chains{eltype(val), typeof(evidence), typeof(name_map_tupl), typeof(info)}(
-                arr, evidence, name_map_tupl, info)
+        return chains
     end
 end
 
@@ -115,11 +114,7 @@ function Chains(c::Chains, section::NTuple{<:Any,Symbol}; sorted::Bool=false)
     value = c.value[:, mapreduce(collect, vcat, name_map), :]
 
     # Create the new chain.
-    chain = Chains{eltype(c.value),typeof(c.logevidence),typeof(name_map),typeof(c.info)}(
-		value,
-        c.logevidence,
-        name_map,
-        c.info)
+    chain = Chains(value, c.logevidence, name_map, c.info)
 
     if sorted
         return sort(chain)
@@ -172,8 +167,7 @@ function Base.getindex(c::Chains, i...)
     newval = getindex(c.value, ind...)
     names = newval.axes[2].val
     new_name_map = _trim_name_map(names, c.name_map)
-    return Chains{eltype(c.value),typeof(c.logevidence),typeof(new_name_map),
-        typeof(c.info)}(newval, c.logevidence, new_name_map, c.info)
+    return Chains(newval, c.logevidence, new_name_map, c.info)
 end
 
 Base.setindex!(c::Chains, v, i...) = setindex!(c.value, v, i...)
@@ -497,8 +491,7 @@ function Base.sort(c::Chains)
     new_name_map = _dict2namedtuple(name_dict)
 
     aa = AxisArray(new_v, new_axes...)
-    return Chains{eltype(c.value),typeof(c.logevidence),typeof(new_name_map),
-        typeof(c.info)}(aa, c.logevidence, new_name_map, c.info)
+    return Chains(aa, c.logevidence, new_name_map, c.info)
 end
 
 """
@@ -513,8 +506,7 @@ new_chn = setinfo(chn, NamedTuple{(:a, :b)}((1, 2)))
 ```
 """
 function setinfo(c::Chains, n::NamedTuple)
-    return Chains{eltype(c.value),typeof(c.logevidence),typeof(c.name_map),typeof(n)}(
-        c.value, c.logevidence, c.name_map, n)
+    return Chains(c.value, c.logevidence, c.name_map, n)
 end
 
 set_section(c::Chains, nt::NamedTuple) = set_section(c, _namedtuple2dict(nt))
@@ -549,8 +541,7 @@ function set_section(c::Chains, d::Dict)
     end
 
     nt = _dict2namedtuple(d)
-    return Chains{eltype(c.value),typeof(c.logevidence),typeof(nt),typeof(c.info)}(
-        c.value, c.logevidence, nt, c.info)
+    return Chains(c.value, c.logevidence, nt, c.info)
 end
 
 function _use_showall(c::Chains, section::Symbol)

--- a/src/heideldiag.jl
+++ b/src/heideldiag.jl
@@ -33,6 +33,7 @@ function heideldiag(chn::Chains;
                     sections::Vector{Symbol}=[:parameters],
                     showall=false,
                     sorted=true,
+                    digits=4,
                     args...
                    )
     c = showall ?
@@ -56,16 +57,23 @@ function heideldiag(chn::Chains;
                            )
     end
 
-    colnames = tuple(Symbol.(["parameters", "Burn-in", "Stationarity", "p-value", "Mean",
-        "Halfwidth", "Test"])...)
+    # Retrieve columns.
+    columns = [[vals[k][:, i] for i in 1:6] for k in 1:m]
 
-    # Round values.
-    pnames = Symbol.(names(c))
-    vals = map(x -> round.(x, digits=4), vals)
-    columns = [vcat([pnames], [vals[k][:,i] for i in 1:6]) for k in 1:m]
+    # Obtain names of parameters.
+    names_of_params = names(chn)
 
-    dfs = [NamedTuple{colnames}(tuple(columns[k]...)) for k in 1:m]
-    dfs_wrapped = [ChainDataFrame("Heidelberger and Welch Diagnostic - Chain $k",
-                   dfs[k]) for k in 1:m]
-    return dfs_wrapped
+    # Compute data frames.
+    vector_of_df = [
+        ChainDataFrame(
+            "Heidelberger and Welch Diagnostic - Chain $i",
+            (parameters = names_of_params, var"Burn-in" = column[1],
+             Stationarity = column[2], var"p-value" = column[3], Mean = column[4],
+             Halfwidth = column[5], Test = column[6]);
+             digits = digits
+        )
+        for (i, column) in enumerate(columns)
+    ]
+
+    return vector_of_df
 end

--- a/src/heideldiag.jl
+++ b/src/heideldiag.jl
@@ -58,21 +58,21 @@ function heideldiag(chn::Chains;
     end
 
     # Retrieve columns.
-    columns = [[vals[k][:, i] for i in 1:6] for k in 1:m]
+    data = [[vals[k][:, i] for i in 1:6] for k in 1:m]
 
     # Obtain names of parameters.
     names_of_params = names(chn)
 
     # Compute data frames.
+    colnames = (Symbol("Burn-in"), :Stationarity, Symbol("p-value"), :Mean, :Halfwidth,
+        :Test)
     vector_of_df = [
         ChainDataFrame(
             "Heidelberger and Welch Diagnostic - Chain $i",
-            (parameters = names_of_params, var"Burn-in" = column[1],
-             Stationarity = column[2], var"p-value" = column[3], Mean = column[4],
-             Halfwidth = column[5], Test = column[6]);
-             digits = digits
+            (parameters = names_of_params, zip(colnames, columns)...);
+            digits = digits
         )
-        for (i, column) in enumerate(columns)
+        for (i, columns) in enumerate(data)
     ]
 
     return vector_of_df

--- a/src/rafterydiag.jl
+++ b/src/rafterydiag.jl
@@ -59,6 +59,7 @@ function rafterydiag(
                      eps = 0.001,
                      showall=false,
                      sorted=true,
+                     digits=4,
                      sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters]
                     )
     c = showall ?
@@ -77,15 +78,22 @@ function rafterydiag(
         )
     end
 
-    colnames = tuple(Symbol.(["parameters", "Thinning", "Burn-in", "Total", "Nmin",
-        "Dependence Factor"])...)
+    # Retrieve columns.
+    columns = [[vals[k][:, i] for i in 1:5] for k in 1:m]
 
-    pnames = Symbol.(names(c))
-    vals = map(x -> round.(x, digits=4), vals)
-    columns = [vcat([pnames], [vals[k][:,i] for i in 1:5]) for k in 1:m]
+    # Obtain names of parameters.
+    names_of_params = names(chn)
 
-    dfs = [NamedTuple{colnames}(tuple(columns[k]...)) for k in 1:m]
-    dfs_wrapped = [ChainDataFrame("Raftery and Lewis Diagnostic - Chain $k",
-                   dfs[k]) for k in 1:m]
-    return dfs_wrapped
+    # Compute data frames.
+    vector_of_df = [
+        ChainDataFrame(
+            "Raftery and Lewis Diagnostic - Chain $i",
+            (parameters = names_of_params, Thinning = column[1], var"Burn-in" = column[2],
+             Total = column[3], Nmin = column[4], var"Dependence Factor" = column[5]);
+            digits = digits
+        )
+        for (i, column) in enumerate(columns)
+    ]
+
+    return vector_of_df
 end

--- a/src/rafterydiag.jl
+++ b/src/rafterydiag.jl
@@ -79,20 +79,20 @@ function rafterydiag(
     end
 
     # Retrieve columns.
-    columns = [[vals[k][:, i] for i in 1:5] for k in 1:m]
+    data = [[vals[k][:, i] for i in 1:5] for k in 1:m]
 
     # Obtain names of parameters.
     names_of_params = names(chn)
 
     # Compute data frames.
+    colnames = (:Thinning, Symbol("Burn-in"), :Total, :Nmin, Symbol("Dependence Factor"))
     vector_of_df = [
         ChainDataFrame(
             "Raftery and Lewis Diagnostic - Chain $i",
-            (parameters = names_of_params, Thinning = column[1], var"Burn-in" = column[2],
-             Total = column[3], Nmin = column[4], var"Dependence Factor" = column[5]);
+            (parameters = names_of_params, zip(colnames, columns)...);
             digits = digits
         )
-        for (i, column) in enumerate(columns)
+        for (i, columns) in enumerate(data)
     ]
 
     return vector_of_df

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -50,34 +50,44 @@ The `digits` keyword may be a(n)
 - `NamedTuple`, which only rounds the named column to the specified digits, as with `(mean=2, std=3)`. This would round the `mean` column to 2 digits and the `std` column to 3 digits.
 - `Dict`, with a similar structure as `NamedTuple`. `Dict(mean => 2, std => 3)` would set `mean` to two digits and `std` to three digits.
 """
-function cor(chn::Chains;
+function cor(chain::Chains;
         showall=false,
         append_chains=true,
-        sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
+        sections::Union{Symbol, Vector{Symbol}}=:parameters,
         digits::Int=4,
-        kwargs...)
-    df = DataFrame(chn, sections, showall=showall, append_chains=append_chains)
+        kwargs...
+)
+    # Obtain interesting subset of the chain.
+    chn = showall ? chain : Chains(chain, sections)
 
-    # Generate
-    cormat = if append_chains
-        cor(convert(Matrix, df[:, 1:end]))
+    # Obstain names of parameters.
+    names_of_params = Symbol.(names(chn))
+
+    if append_chains
+        df = chaindataframe_cor("Correlation", names_of_params, to_matrix(chn);
+                                digits = digits)
+        return df
     else
-        [cor(convert(Matrix, i[:, 1:end])) for i in df]
+        vector_of_df = [
+            chaindataframe_cor(
+                "Correlation - Chain $i", names_of_params, data; digits = digits
+            )
+            for (i, data) in enumerate(to_vector_of_matrices(chn))
+        ]
+        return vector_of_df
     end
-    nms = append_chains ? names(df) : names(df[1])
-    columns = if append_chains
-        [nms, [cormat[:, i] for i in 1:size(cormat, 2)]...]
-    else
-        [[nms, [cm[:, i] for i in 1:size(cm, 2)]...] for cm in cormat]
-    end
-    colnames = vcat([:parameters], nms...)
-    df_summary = if append_chains
-        ChainDataFrame("Correlation", DataFrame(columns, colnames), digits=digits)
-    else
-        [ChainDataFrame("Correlation", DataFrame(c, colnames), digits=digits)
-            for c in columns]
-    end
-    return df_summary
+end
+
+function chaindataframe_cor(name, names_of_params, chains::AbstractMatrix; kwargs...)
+    # Compute the correlation matrix.
+    cormat = cor(chains)
+
+    # Summarize the results in a named tuple.
+    nt = (; parameters = names_of_params,
+          zip(names_of_params, (cormat[:, i] for i in axes(cormat, 2)))...)
+
+    # Create a ChainDataFrame.
+    return ChainDataFrame(name, nt; kwargs...)
 end
 
 """
@@ -95,42 +105,70 @@ The `digits` keyword may be a(n)
 - `NamedTuple`, which only rounds the named column to the specified digits, as with `(mean=2, std=3)`. This would round the `mean` column to 2 digits and the `std` column to 3 digits.
 - `Dict`, with a similar structure as `NamedTuple`. `Dict(mean => 2, std => 3)` would set `mean` to two digits and `std` to three digits.
 """
-function changerate(chn::Chains;
+function changerate(chains::Chains{<:Real};
     append_chains=true,
     showall=false,
     sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
     digits::Int=4,
-    kwargs...)
-    # Check for missing values.
-    @assert !any(ismissing.(chn.value)) "Change rate comp. doesn't support missing values."
+    kwargs...
+)
+    # Obtain interesting subset of the chains.
+    chn = showall ? chains : Chains(chains, sections)
 
-    df = DataFrame(chn, append_chains=true, showall=showall)
-    n, p = size(df[1])
-    m = length(chains(chn))
+    # Obstain names of parameters.
+    names_of_params = Symbol.(names(chn))
 
-    r = zeros(Float64, p, 1, 1)
-    r_mv = 0.0
-    delta = Array{Bool}(undef, p)
-    for k in 1:m
-        dfk = df[k]
-        prev = convert(Vector, dfk[1,:])
-        for i in 2:n
-            for j in 1:p
-                x = dfk[i, j]
-                dx = x != prev[j]
-                r[j] += dx
-                delta[j] = dx
-                prev[j] = x
-            end
-            r_mv += any(delta)
-        end
+    if append_chains
+        df = chaindataframe_changerate("Change Rate", names_of_params, chn.value.data)
+        return df
+    else
+        vector_of_df = [
+            chaindataframe_changerate(
+                "Change Rate - Chain $i", names_of_params, data; digits = digits
+            )
+            for (i, data) in enumerate(to_vector_of_matrices(chn))
+        ]
+        return vector_of_df
     end
-    vals = round.([r..., r_mv] / (m * (n - 1)), digits = 3)
-    rownames = push!(names(df[1]), :multivariate)
-    return DataFrame(parameters = rownames,
-        change_rate = vals,
-        name="Change Rate",
-        digits=digits)
+end
+
+function chaindataframe_changerate(name, names_of_params, chains; kwargs...)
+    # Compute the change rates.
+    changerates, mvchangerate = chains
+
+    # Summarize the results in a named tuple.
+    nt = (; zip(names_of_params, changerates)..., multivariate = mvchangerate)
+
+    # Create a ChainDataFrame.
+    return ChainDataFrame(name, nt; kwargs...)
+end
+
+changerate(chains::AbstractMatrix{<:Real}) = changerate(reshape(chains, Val(3)))
+function changerate(chains::AbstractArray{<:Real,3})
+    niters, nparams, nchains = size(chains)
+
+    changerates = zeros(nparams)
+    mvchangerate = 0.0
+
+    for chain in 1:nchains, iter in 2:niters
+        isanychanged = false
+
+        for param in 1:nparams
+            # update if the sample is different from the one in the previous iteration
+            if chains[iter-1, param, chain] != chains[iter, param, chain]
+                changerates[param] += 1
+                isanychanged = true
+            end
+        end
+
+        mvchangerate += isanychanged
+    end
+
+    factor = nchains * (niters - 1)
+    changerates ./= factor
+    mvchangerate /= factor
+
+    changerates, mvchangerate
 end
 
 describe(c::Chains; args...) = describe(stdout, c; args...)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -216,7 +216,7 @@ function describe(io::IO,
     return dfs
 end
 
-function _hpd(x::Vector{<:Real}; alpha::Real=0.05)
+function _hpd(x::AbstractVector{<:Real}; alpha::Real=0.05)
     n = length(x)
     m = max(1, ceil(Int, alpha * n))
 
@@ -228,20 +228,11 @@ function _hpd(x::Vector{<:Real}; alpha::Real=0.05)
     return [a[i], b[i]]
 end
 
-function hpd(chn::Chains; alpha::Real=0.05,
-        append_chains=true,
-        showall=false,
-        sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-        digits=nothing)
+function hpd(chn::Chains; alpha::Real=0.05, kwargs...)
     labels = [:upper, :lower]
     u(x) = _hpd(x, alpha=alpha)[1]
     l(x) = _hpd(x, alpha=alpha)[2]
-    return summarize(chn, u, l;
-        func_names = labels,
-        showall=showall,
-        sections=sections,
-        name="HPD",
-        digits=digits)
+    return summarize(chn, u, l; name = "HPD", func_names = labels, kwargs...)
 end
 
 """

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -233,8 +233,7 @@ function summarize(chains::Chains, funs...;
     # Generate a chain to work on.
     chn = Chains(chains, sections, sorted=sorted)
 
-    # Obtain data and names of parameters.
-    data = chn.value.data
+    # Obtain names of parameters.
     names_of_params = names(chn)
 
     # If no function names were given, make a new list.
@@ -245,7 +244,8 @@ function summarize(chains::Chains, funs...;
 
     if append_chains
         # Evaluate the functions.
-        fvals = [[f(data[:,col,:]) for col in axes(data, 2)] for f in funs]
+        data = to_matrix(chn)
+        fvals = [[f(data[:, i]) for i in axes(data, 2)] for f in funs]
 
         # Build the ChainDataFrame.
         nt = merge((; parameters = names_of_params, zip(fnames, fvals)...), additional_nt)
@@ -254,10 +254,8 @@ function summarize(chains::Chains, funs...;
         return df
     else
         # Evaluate the functions.
-        vector_of_fvals = [
-            [[f(data[:, col, i]) for col in axes(data, 2)] for f in funs]
-            for i in axes(data, 3)
-        ]
+        data = to_vector_of_matrices(chn)
+        vector_of_fvals = [[[f(x[:, i]) for i in axes(x, 2)] for f in funs] for x in data]
 
         # Build the ChainDataFrames.
         vector_of_nt = [

--- a/test/arrayconstructor_tests.jl
+++ b/test/arrayconstructor_tests.jl
@@ -42,11 +42,11 @@ using MCMCChains, Test
         @test Array(chns_a; append_chains = false, remove_missing_union = false) isa
             Vector{Vector{Union{Missing,Real}}}
 
-        # type inference
-        @inferred MCMCChains.to_matrix(chns)
-        @inferred MCMCChains.to_vector(chns)
-        @inferred MCMCChains.to_vector_of_vectors(chns_a)
-        @inferred MCMCChains.to_vector_of_matrices(chns)
+        # type inference (needs concretely typed Chains)
+        @test_broken @inferred MCMCChains.to_matrix(chns)
+        @test_broken @inferred MCMCChains.to_vector(chns)
+        @test_broken @inferred MCMCChains.to_vector_of_vectors(chns_a)
+        @test_broken @inferred MCMCChains.to_vector_of_matrices(chns)
 
         # sizes
         @test size(Array(chns)) == (d*c, main_params)

--- a/test/dfconstructor_tests.jl
+++ b/test/dfconstructor_tests.jl
@@ -39,6 +39,29 @@ using DataFrames
     @test size(df8) == (4, )
     @test size(df8[1]) == (1000, 8)
 end
+
+@testset "concretize of DataFrame" begin
+    val = rand(10, 4, 4)
+    chn = Chains(val, ["a", "b", "c", "d"])
+
+    df = DataFrame(chn)
+    @test MCMCChains.concretize(df) === df
+
+    val2 = convert(Array{Union{Missing,Real}}, val)
+    chn2 = Chains(val2, ["a", "b", "c", "d"])
+
+    df2 = DataFrame(chn2)
+    @test all(x -> eltype(x) === Float64, eachcol(df2))
+    @test df2 == df
+
+    df3 = DataFrame(chn2; remove_missing_union = false)
+    @test all(x -> eltype(x) === Union{Missing,Real}, eachcol(df3))
+    
+    df4 = MCMCChains.concretize(df2)
+    @test all(x -> eltype(x) === Float64, eachcol(df4))
+    @test df4 == df
+end
+
 @testset "ChainDataFrame converter" begin
     val = rand(1000, 5, 4)
     chain = Chains(val)

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -66,6 +66,9 @@ end
 
     @test MCMCChains.changerate(chn) isa ChainDataFrame
     @test MCMCChains.changerate(chn; append_chains = false) isa Vector{<:ChainDataFrame}
+
+    @test hpd(chn) isa ChainDataFrame
+    @test hpd(chn; append_chains = false) isa Vector{<:ChainDataFrame}
 end
 
 @testset "vector of vectors" begin

--- a/test/diagnostic_tests.jl
+++ b/test/diagnostic_tests.jl
@@ -57,6 +57,17 @@ end
     @test eltype(rafterydiag(chn[:,1,:])) <: ChainDataFrame
 end
 
+@testset "stats tests" begin
+    @test autocor(chn) isa Vector{<:ChainDataFrame}
+    @test autocor(chn; append_chains = false) isa Vector{<:ChainDataFrame}
+
+    @test MCMCChains.cor(chn) isa ChainDataFrame
+    @test MCMCChains.cor(chn; append_chains = false) isa Vector{<:ChainDataFrame}
+
+    @test MCMCChains.changerate(chn) isa ChainDataFrame
+    @test MCMCChains.changerate(chn; append_chains = false) isa Vector{<:ChainDataFrame}
+end
+
 @testset "vector of vectors" begin
     val = [rand(20) for _ in 1:10]
 


### PR DESCRIPTION
This PR contains the following changes:
- It adds an unexported `concretize` method that can be used to transform a `Chains`, `AbstractDataFrame`, or (possibly nested) `AbstractArray` with element types that are not concretely typed (such as `Real` or `Union{Missing,Float64}`) to a version with concretely typed element types if possible (clearly it can be type stable only if all element types are already concretely type in which case it just returns the input)
- It adds separate functions to transform a `Chains` to a matrix, a vector of scalars, a vector of vectors, and a vector of matrices and makes use of these functions in the `Array` constructor
- It removes an abstract field in `Chains` by adding an additional type parameter, which, e.g., makes the functions in the last point inferrable and type stable (at least for the arguments that are used in the tests)

A side remark:
I'm not happy about the `Array` and `DataFrame` constructors since it it is impossible to infer their return types and they can't be type stable. Actually, I think we should consider removing them and instead export functions that return ALWAYS vectors of matrices (i.e., matrices for each chain) or matrices (i.e., with all chains appended). In particular, I think we should stop dropping the last dimension if there is only one parameter (this conversion/reshaping should only happen downstream if it is needed, similar to the behaviour of `sum` etc.), and we should remove most of the keyword arguments - IMO instead of always providing `section` keyword arguments users should just compute the subset of the chain they are interested in before hand, they should sort the chain by using the sorting functionality, and they should concretize the chain outside of these functions (ideally they know which types to expect, so they can perform some proper conversion instead of using the type unstable `concretize` approach).