### PR TITLE
Test only on LTS, stable, and master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,7 @@ os:
 
 julia:
   - 1.0
-  - 1.1
-  - 1.2
-  - 1.3
-  - 1.4
+  - 1
   - nightly
 
 matrix:
@@ -26,7 +23,7 @@ notifications:
   email: false
 
 after_success:
-  - if [[ $TRAVIS_JULIA_VERSION = 1.4 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
+  - if [[ $TRAVIS_JULIA_VERSION = 1 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
       julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())';
       julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())';
     fi


### PR DESCRIPTION
I noticed that we run a ridiculous amount of tests. IMO testing with the LTS, stable, and latest Julia versions should be sufficient.