### PR TITLE
Remove `showall` and reintroduced `digits` keyword arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,10 @@ b 0.0001 0.2290 0.4972 0.7365 0.9998
 c 0.0004 0.2739 0.5137 0.7498 0.9997
 ```
 
-Note that only `a`, `b`, and `c` are being shown. You can explicity show the `:internals` section by calling `describe(chn, sections=:internals)` or all variables with `describe(chn, showall=true)`. Most MCMCChains functions like `plot` or `gelmandiag` support the `section` and `showall` keyword arguments.
+Note that only `a`, `b`, and `c` are being shown. You can explicity show the `:internals`
+section by calling `describe(chn; sections = :internals)` or all variables with
+`describe(chn; sections = nothing)`. Many functions such as `plot` or `gelmandiag`
+support the `sections` keyword argument.
 
 ### Groups of parameters
 

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -70,8 +70,7 @@ end
 Chains(c::Chains, section::Union{Symbol,String}) = Chains(c, (section,))
 function Chains(chn::Chains, sections)
     # Make sure the sections exist first.
-    allsections = keys(chn.name_map)
-	  all(x -> Symbol(x) in allsections, sections) ||
+	  all(haskey(chn.name_map, Symbol(x)) for x in sections) ||
 		    error("some sections are not present in the chain")
 
 	  # Create the new section map.
@@ -311,19 +310,14 @@ function Base.names(c::Chains, sections)
 end
 
 """
-    get_sections(c::Chains, sections::Vector = [])
+    get_sections(chains[, sections])
 
 Returns multiple `Chains` objects, each containing only a single section.
 """
-function get_sections(c::Chains, sections::Vector = [])
-    sections = length(sections) == 0 ? collect(keys(c.name_map)) : sections
-    return [Chains(c, section) for section in sections]
+function get_sections(chains::Chains, sections = keys(chains.name_map))
+    return [Chains(chains, section) for section in sections]
 end
-
-# Return a new chain for each section.
-function get_sections(c::Chains, section::Union{Symbol, String})
-    return get_sections(c, [section])
-end
+get_sections(chains::Chains, section::Union{Symbol, String}) = Chains(chains, section)
 
 """
     sections(c::Chains)
@@ -495,10 +489,15 @@ function set_section(chains::Chains, namemap)
     return Chains(chains.value, chains.logevidence, _namemap, chains.info)
 end
 
-function _clean_sections(c::Chains, sections::Union{Vector{Symbol}, Symbol})
-    sections = sections isa AbstractArray ? sections : [sections]
-    ks = collect(keys(c.name_map))
-    return ks ∩ sections
+_default_sections(c::Chains) = haskey(c.name_map, :parameters) ? :parameters : nothing
+
+function _clean_sections(chains::Chains, sections)
+    return filter(sections) do section
+        haskey(chains.name_map, Symbol(section))
+    end
+end
+function _clean_sections(chains::Chains, section::Union{String,Symbol})
+    return haskey(chains.name_map, Symbol(section)) ? section : ()
 end
 _clean_sections(::Chains, ::Nothing) = nothing
 

--- a/src/chains.jl
+++ b/src/chains.jl
@@ -71,10 +71,10 @@ Chains(c::Chains, section::Union{Symbol,String}) = Chains(c, (section,))
 function Chains(chn::Chains, sections)
     # Make sure the sections exist first.
     allsections = keys(chn.name_map)
-	all(x -> Symbol(x) in allsections, sections) ||
-		error("some sections are not present in the chain")
+	  all(x -> Symbol(x) in allsections, sections) ||
+		    error("some sections are not present in the chain")
 
-	# Create the new section map.
+	  # Create the new section map.
     name_map = (; (Symbol(k) => chn.name_map[Symbol(k)] for k in sections)...)
 
     # Extract wanted values.
@@ -83,6 +83,7 @@ function Chains(chn::Chains, sections)
     # Create the new chain.
     return Chains(value, chn.logevidence, name_map, chn.info)
 end
+Chains(chain::Chains, ::Nothing) = chain
 
 # Groups of parameters
 
@@ -499,6 +500,8 @@ function _clean_sections(c::Chains, sections::Union{Vector{Symbol}, Symbol})
     ks = collect(keys(c.name_map))
     return ks ∩ sections
 end
+_clean_sections(::Chains, ::Nothing) = nothing
+
 
 #################### Concatenation ####################
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -19,7 +19,7 @@ function sort_sections(chn::Chains)
 end
 
 """
-    Array(chains[, sections = :parameters;
+    Array(chains[, sections;
           append_chains = true, remove_missing_union = true])
 
 Construct an `Array` from a chain.
@@ -31,15 +31,15 @@ cde(), etc.
 # Examples
 
 * `Array(chns)` : Array with chain values are appended
-* `Array(chns[:par])` : Array with selected parameter chain values are appended
+* `Array(chns[[:par]])` : Array with selected parameter chain values are appended
 * `Array(chns, :parameters)`  : Array with only :parameter section
 * `Array(chns, [:parameters, :internals])`  : Array includes multiple sections
-* `Array(chns, append_chains=false)`  : Array of Arrays, each chain in its own array
-* `Array(chns, remove_missing_union=false)` : No conversion to remove missing values
+* `Array(chns; append_chains=false)`  : Array of Arrays, each chain in its own array
+* `Array(chns; remove_missing_union=false)` : No conversion to remove missing values
 """
 function Base.Array(
     chains::Chains,
-    sections = :parameters;
+    sections = _default_sections(chains);
     append_chains = true,
     remove_missing_union = true
 )

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -19,58 +19,32 @@ function sort_sections(chn::Chains)
 end
 
 """
+    Array(chains[, sections = :parameters;
+          append_chains = true, remove_missing_union = true])
 
-# Array
+Construct an `Array` from a chain.
 
-Array constructor from a Chains object. Returns 3 dimensionsal
-array or an Array of 2 dimensional Arrays. If only a single parameter is selected for
-inclusion, a dimension is dropped in both cases, as is e.g. required by cde(), etc.
+Returns 3 dimensionsal array or an Array of 2 dimensional Arrays. If only a single parameter
+is selected for inclusion, a dimension is dropped in both cases, as is e.g. required by
+cde(), etc.
 
-### Method
-```julia
-  Array(
-    chn::Chains,
-    sections::Vector{Symbol};
-    append_chains::Bool,
-    remove_missing_union::Bool
-  )
-```
+# Examples
 
-### Required arguments
-```julia
-* `chn` : Chains object to convert to an Array
-```
-
-### Optional arguments
-```julia
-* `sections = Symbol[]` : Sections from the Chains object to be included
-* `append_chains = true`  : Append chains into a single column
-* `remove_missing_union = true`  : Convert Union{Missing, Real} to Float64
-```
-
-### Examples
-```julia
 * `Array(chns)` : Array with chain values are appended
 * `Array(chns[:par])` : Array with selected parameter chain values are appended
-* `Array(chns, [:parameters])`  : Array with only :parameter section
+* `Array(chns, :parameters)`  : Array with only :parameter section
 * `Array(chns, [:parameters, :internals])`  : Array includes multiple sections
 * `Array(chns, append_chains=false)`  : Array of Arrays, each chain in its own array
 * `Array(chns, remove_missing_union=false)` : No conversion to remove missing values
-```
-
 """
-function Base.Array(chain::Chains,
-    sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters];
+function Base.Array(
+    chains::Chains,
+    sections = :parameters;
     append_chains = true,
-    remove_missing_union = true,
-    showall = false
+    remove_missing_union = true
 )
-    sections = showall ? keys(chain.name_map) : sections
-    if remove_missing_union
-        chn = concretize(Chains(chain, sections))
-    else
-        chn = Chains(chain, sections)
-    end
+    _chains = Chains(chains, _clean_sections(chains, sections))
+    chn = remove_missing_union ? concretize(_chains) : _chains
 
     nparams = size(chn, 2)
     if append_chains

--- a/src/discretediag.jl
+++ b/src/discretediag.jl
@@ -370,7 +370,7 @@ end
 
 function discretediag(
     chains::Chains{<:Real};
-    sections = :parameters,
+    sections = _default_sections(chains),
     frac::Real = 0.3,
     method::Symbol = :weiss,
     nsim::Int = 1000

--- a/src/gelmandiag.jl
+++ b/src/gelmandiag.jl
@@ -80,19 +80,13 @@ end
 
 function gelmandiag(
     chains::Chains{<:Real};
-    sections::Union{Symbol, Vector{Symbol}} = :parameters,
-    showall = false,
+    sections = :parameters,
     transform = false,
     alpha = 0.05,
-    digits = 4,
     kwargs...
 )
     # Subset the chain.
-    if showall
-        _chains = chains
-    else
-        _chains = Chains(chains, _clean_sections(chains, sections))
-    end
+    _chains = Chains(chains, _clean_sections(chains, sections))
 
     # Compute the potential scale reduction factor.
     psi = transform ? link(_chains) : _chains.value.data
@@ -102,24 +96,18 @@ function gelmandiag(
     colnames = (:psrf, Symbol(100 * (1 - alpha / 2), :%))
     nt = (; parameters = names(_chains), zip(colnames, results)...)
 
-    return ChainDataFrame("Gelman, Rubin, and Brooks Diagnostic", nt; digits = digits)
+    return ChainDataFrame("Gelman, Rubin, and Brooks Diagnostic", nt)
 end
 
 function gelmandiag_multivariate(
     chains::Chains{<:Real};
-    sections::Union{Symbol, Vector{Symbol}} = :parameters,
-    showall = false,
+    sections = :parameters,
     transform = true,
     alpha = 0.05,
-    digits = 4,
     kwargs...
 )
     # Subset the chain.
-    if showall
-        _chains = chains
-    else
-        _chains = Chains(chains, _clean_sections(chains, sections))
-    end
+    _chains = Chains(chains, _clean_sections(chains, sections))
 
     # Compute the potential scale reduction factor.
     psi = transform ? link(_chains) : _chains.value.data
@@ -129,6 +117,6 @@ function gelmandiag_multivariate(
     colnames = (:psrf, Symbol(100 * (1 - alpha / 2), :%))
     nt = (; parameters = names(_chains), zip(colnames, (results.psrf, results.psrfci))...)
 
-    return ChainDataFrame("Gelman, Rubin, and Brooks Diagnostic", nt; digits = digits),
+    return ChainDataFrame("Gelman, Rubin, and Brooks Diagnostic", nt),
         results.multivariate
 end

--- a/src/gelmandiag.jl
+++ b/src/gelmandiag.jl
@@ -80,7 +80,7 @@ end
 
 function gelmandiag(
     chains::Chains{<:Real};
-    sections = :parameters,
+    sections = _default_sections(chains),
     transform = false,
     alpha = 0.05,
     kwargs...
@@ -101,7 +101,7 @@ end
 
 function gelmandiag_multivariate(
     chains::Chains{<:Real};
-    sections = :parameters,
+    sections = _default_sections(chains),
     transform = true,
     alpha = 0.05,
     kwargs...

--- a/src/gewekediag.jl
+++ b/src/gewekediag.jl
@@ -19,10 +19,10 @@ end
 
 function gewekediag(
     chains::Chains;
-    first::Real=0.1,
-    last::Real=0.5,
-    etype=:imse,
-    sections = :parameters,
+    sections = _default_sections(chains),
+    first::Real = 0.1,
+    last::Real = 0.5,
+    etype = :imse,
     kwargs...
 )
     # Subset the chain.

--- a/src/gewekediag.jl
+++ b/src/gewekediag.jl
@@ -17,27 +17,31 @@ function gewekediag(x::Vector{<:Real}; first::Real=0.1, last::Real=0.5,
   [z, 1 - erf(abs(z) / sqrt(2))]
 end
 
-function gewekediag(chn::Chains; first::Real=0.1, last::Real=0.5,
-                    etype=:imse,
-                    sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-                    showall=false,
-                    args...)
-    c = showall ? chn : Chains(chn, _clean_sections(chn, sections))
+function gewekediag(
+    chains::Chains;
+    first::Real=0.1,
+    last::Real=0.5,
+    etype=:imse,
+    sections = :parameters,
+    kwargs...
+)
+    # Subset the chain.
+    _chains = Chains(chains, _clean_sections(chains, sections))
 
-    _, p, m = size(c.value)
+    _, p, m = size(_chains.value)
     diags = [Array{Float64}(undef, p, 2) for _ in 1:m]
     for j in 1:p, k in 1:m
         diags[k][j,:] = gewekediag(
-                            collect(skipmissing(c.value[:, j, k])),
+                            collect(skipmissing(_chains.value[:, j, k])),
                             first=first,
                             last=last,
                             etype=etype;
-                            args...
+                            kwargs...
                         )
     end
 
     # Obtain names of parameters.
-    names_of_params = names(chn)
+    names_of_params = names(_chains)
 
     # Compute data frames.
     vector_of_df = [

--- a/src/heideldiag.jl
+++ b/src/heideldiag.jl
@@ -28,10 +28,10 @@ end
 
 function heideldiag(
     chains::Chains;
+    sections = _default_sections(chains),
     alpha = 0.05,
     eps = 0.1,
     etype = :imse,
-    sections = :parameters,
     kwargs...
 )
     # Subset the chain.

--- a/src/heideldiag.jl
+++ b/src/heideldiag.jl
@@ -26,30 +26,30 @@ function heideldiag(x::Vector{<:Real}; alpha::Real=0.05, eps::Real=0.1,
   [i + start - 2, converged, pvalue, ybar, halfwidth, passed]
 end
 
-function heideldiag(chn::Chains;
-                    alpha = 0.05,
-                    eps = 0.1,
-                    etype = :imse,
-                    sections::Vector{Symbol}=[:parameters],
-                    showall=false,
-                    args...
-                   )
-    c = showall ? chn : Chains(chn, _clean_sections(chn, sections))
+function heideldiag(
+    chains::Chains;
+    alpha = 0.05,
+    eps = 0.1,
+    etype = :imse,
+    sections = :parameters,
+    kwargs...
+)
+    # Subset the chain.
+    _chains = Chains(chains, _clean_sections(chains, sections))
 
     # Preallocate.
-    _, p, m = size(c.value)
+    _, p, m = size(_chains.value)
     vals = [Array{Float64}(undef, p, 6) for i in 1:m]
-
 
     # Perform tests.
     for j in 1:p, k in 1:m
         vals[k][j, :] = heideldiag(
-                            collect(skipmissing(c.value[:, j, k])),
+                            collect(skipmissing(_chains.value[:, j, k])),
                             alpha=alpha,
                             eps=eps,
                             etype=etype,
-                            start=first(c);
-                            args...
+                            start=first(_chains);
+                            kwargs...
                            )
     end
 
@@ -57,7 +57,7 @@ function heideldiag(chn::Chains;
     data = [[vals[k][:, i] for i in 1:6] for k in 1:m]
 
     # Obtain names of parameters.
-    names_of_params = names(chn)
+    names_of_params = names(_chains)
 
     # Compute data frames.
     vector_of_df = [

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -30,7 +30,6 @@ const supportedplots = push!(collect(keys(translationdict)), :mixeddensity, :cor
     colordim = :chain,
     barbounds = (-Inf, Inf),
     maxlag = nothing,
-    sections = :parameters,
     append_chains = false
 )
     st = get(plotattributes, :seriestype, :traceplot)
@@ -125,7 +124,7 @@ end
 @recipe function f(
     chains::Chains,
     parameters::AbstractVector{<:Integer} = Int[];
-    sections = :parameters,
+    sections = _default_sections(chains),
     width = 500,
     height = 250,
     colordim = :chain,

--- a/src/rafterydiag.jl
+++ b/src/rafterydiag.jl
@@ -52,25 +52,26 @@ function rafterydiag(
 end
 
 function rafterydiag(
-                     chn::Chains;
-                     q = 0.025,
-                     r = 0.005,
-                     s = 0.95,
-                     eps = 0.001,
-                     showall=false,
-                     sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters]
-                    )
-    c = showall ? chn : Chains(chn, _clean_sections(chn, sections))
-    _, p, m = size(c.value)
+    chains::Chains;
+    sections = :parameters,
+    q = 0.025,
+    r = 0.005,
+    s = 0.95,
+    eps = 0.001
+)
+    # Subset the chain.
+    _chains = Chains(chains, _clean_sections(chains, sections))
+
+    _, p, m = size(_chains.value)
     vals = [Array{Float64}(undef, p, 5) for i in 1:m]
     for j in 1:p, k in 1:m
         vals[k][j, :] = rafterydiag(
-            collect(skipmissing(c.value[:, j, k])),
+            collect(skipmissing(_chains.value[:, j, k])),
             q=q,
             r=r,
             s=s,
             eps=eps,
-            range=range(c)
+            range=range(_chains)
         )
     end
 
@@ -78,7 +79,7 @@ function rafterydiag(
     data = [[vals[k][:, i] for i in 1:5] for k in 1:m]
 
     # Obtain names of parameters.
-    names_of_params = names(chn)
+    names_of_params = names(_chains)
 
     # Compute data frames.
     vector_of_df = [

--- a/src/rafterydiag.jl
+++ b/src/rafterydiag.jl
@@ -53,7 +53,7 @@ end
 
 function rafterydiag(
     chains::Chains;
-    sections = :parameters,
+    sections = _default_sections(chains),
     q = 0.025,
     r = 0.005,
     s = 0.95,

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -1,64 +1,63 @@
 #################### Posterior Statistics ####################
 """
-    autocor(chn;
-        lags=[1, 5, 10, 50],
-        demean=true,
-        relative=true
-        showall=false,
-        append_chains=true,
-        sections=[:parameters])
+    autocor(chains[; lags = [1, 5, 10, 50], demean = true, append_chains = true, kwargs...])
 
-Compute the autocorrelation of each parameter for the chain. Setting `append_chains=false`
-will return a vector of dataframes containing the autocorrelations for each chain.
+Compute the autocorrelation of each parameter for the chain.
+
+Setting `append_chains=false` will return a vector of dataframes containing the
+autocorrelations for each chain.
 """
-function autocor(chn::Chains;
-        lags::AbstractVector{<:Integer}=[1, 5, 10, 50],
-        demean::Bool=true,
-        relative::Bool=true,
-        showall=false,
-        append_chains = false,
-        sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-        kwargs...)
+function autocor(
+    chains::Chains;
+    lags::AbstractVector{<:Integer} = [1, 5, 10, 50],
+    demean::Bool = true,
+    append_chains = false,
+    kwargs...
+)
     funs = Function[]
     func_names = @. Symbol("lag ", lags)
     for i in lags
         push!(funs, x -> autocor(x, [i], demean=demean)[1])
     end
-    return summarize(chn, funs...;
+
+    return summarize(
+        chains, funs...;
         func_names = func_names,
-        showall = showall,
-        sections = sections,
         append_chains = append_chains,
-        name = "Autocorrelation")
+        name = "Autocorrelation",
+        kwargs...
+    )
 end
 
 """
-    cor(chn; showall=false, append_chains=true, sections=[:parameters])
+    cor(chains[; sections = :parameters, append_chains = true, kwargs...])
 
-Compute the Pearson correlation matrix for the chain. Setting `append_chains=false` will
-return a vector of dataframes containing a correlation matrix for each chain.
+Compute the Pearson correlation matrix for the chain.
+
+Setting `append_chains=false` will return a vector of dataframes containing a correlation
+matrix for each chain.
 """
-function cor(chain::Chains;
-        showall=false,
-        append_chains=true,
-        sections::Union{Symbol, Vector{Symbol}}=:parameters,
-        kwargs...
+function cor(
+    chains::Chains;
+    sections = :parameters,
+    append_chains = true,
+    kwargs...
 )
-    # Obtain interesting subset of the chain.
-    chn = showall ? chain : Chains(chain, sections)
+    # Subset the chain.
+    _chains = Chains(chains, _clean_sections(chains, sections))
 
     # Obstain names of parameters.
-    names_of_params = Symbol.(names(chn))
+    names_of_params = names(_chains)
 
     if append_chains
-        df = chaindataframe_cor("Correlation", names_of_params, to_matrix(chn))
+        df = chaindataframe_cor("Correlation", names_of_params, to_matrix(_chains))
         return df
     else
         vector_of_df = [
             chaindataframe_cor(
                 "Correlation - Chain $i", names_of_params, data
             )
-            for (i, data) in enumerate(to_vector_of_matrices(chn))
+            for (i, data) in enumerate(to_vector_of_matrices(_chains))
         ]
         return vector_of_df
     end
@@ -77,35 +76,34 @@ function chaindataframe_cor(name, names_of_params, chains::AbstractMatrix; kwarg
 end
 
 """
-    changerate(chn;
-        append_chains=true,
-        showall=false,
-        sections=[:parameters])
+    changerate(chains[; sections = :parameters, append_chains = true, kwargs...])
 
-Computes the change rate for the chain. Setting `append_chains=false` will
-return a vector of dataframes containing the change rates for each chain.
+Compute the change rate for the chain.
+
+Setting `append_chains=false` will return a vector of dataframes containing the change
+rates for each chain.
 """
-function changerate(chains::Chains{<:Real};
-    append_chains=true,
-    showall=false,
-    sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
+function changerate(
+    chains::Chains{<:Real};
+    sections = :parameters,
+    append_chains = true,
     kwargs...
 )
-    # Obtain interesting subset of the chains.
-    chn = showall ? chains : Chains(chains, sections)
+    # Subset the chain.
+    _chains = Chains(chains, _clean_sections(chains, sections))
 
     # Obstain names of parameters.
-    names_of_params = Symbol.(names(chn))
+    names_of_params = names(_chains)
 
     if append_chains
-        df = chaindataframe_changerate("Change Rate", names_of_params, chn.value.data)
+        df = chaindataframe_changerate("Change Rate", names_of_params, _chains.value.data)
         return df
     else
         vector_of_df = [
             chaindataframe_changerate(
                 "Change Rate - Chain $i", names_of_params, data
             )
-            for (i, data) in enumerate(to_vector_of_matrices(chn))
+            for (i, data) in enumerate(to_vector_of_matrices(_chains))
         ]
         return vector_of_df
     end
@@ -153,33 +151,22 @@ end
 describe(c::Chains; args...) = describe(stdout, c; args...)
 
 """
-    describe(io::IO,
-        c::Chains;
-        q = [0.025, 0.25, 0.5, 0.75, 0.975],
-        etype=:bm,
-        showall=false,
-        sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-        args...)
+    describe(io, chains[;
+             q = [0.025, 0.25, 0.5, 0.75, 0.975],
+             etype = :bm,
+             kwargs...])
 
-Prints the summary statistics and quantiles for the chain.
+Print the summary statistics and quantiles for the chain.
 """
-function describe(io::IO,
-                  c::Chains;
-                  q = [0.025, 0.25, 0.5, 0.75, 0.975],
-                  etype=:bm,
-                  showall::Bool=false,
-                  sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-                  args...
-                 )
-    dfs = vcat(summarystats(c,
-                showall=showall,
-                sections=sections,
-                etype=etype,
-                args...),
-           quantile(c,
-                showall=showall,
-                sections=sections,
-                q=q))
+function describe(
+    io::IO,
+    chains::Chains;
+    q = [0.025, 0.25, 0.5, 0.75, 0.975],
+    etype = :bm,
+    kwargs...
+)
+    dfs = vcat(summarystats(chains; etype = etype, kwargs...),
+               quantile(chains; q = q, kwargs...))
     return dfs
 end
 
@@ -203,21 +190,18 @@ function hpd(chn::Chains; alpha::Real=0.05, kwargs...)
 end
 
 """
-    quantile(chn;
-        q=[0.025, 0.25, 0.5, 0.75, 0.975],
-        append_chains=true,
-        showall=false,
-        sections=[:parameters])
+    quantile(chains[; q = [0.025, 0.25, 0.5, 0.75, 0.975], append_chains = true, kwargs...])
 
-Computes the quantiles for each parameter in the chain. Setting `append_chains=false` will
-return a vector of dataframes containing the quantiles for each chain.
+Compute the quantiles for each parameter in the chain.
+
+Setting `append_chains=false` will return a vector of dataframes containing the quantiles
+for each chain.
 """
 function quantile(
-    chn::Chains;
-    q::Vector=[0.025, 0.25, 0.5, 0.75, 0.975],
-    append_chains=true,
-    showall=false,
-    sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters]
+    chains::Chains;
+    q::AbstractVector = [0.025, 0.25, 0.5, 0.75, 0.975],
+    append_chains = true,
+    kwargs...
 )
     # compute quantiles
     funs = Function[]
@@ -226,34 +210,35 @@ function quantile(
         push!(funs, x -> quantile(cskip(x), i))
     end
 
-    return summarize(chn, funs...;
-        func_names=func_names,
-        showall=showall,
-        sections=sections,
-        name="Quantiles",
-        append_chains=append_chains
+    return summarize(
+        chains, funs...;
+        func_names = func_names,
+        append_chains = append_chains,
+        name = "Quantiles",
+        kwargs...
     )
 end
 
 """
-	ess(chn::Chains;
-		showall=false,
-		sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-		maxlag = 250)
+	  ess(chn::Chains[;	sections = :parameters, kwargs...])
 
-Compute a chain's number of effective samples. More information can be found in the Gelman
-et al. (2014) book "Bayesian Data Analysis", or in
-[this article](https://arxiv.org/abs/1903.08008).
+Compute the effective sample size (ESS) of a chain.
+
+More information can be found in the Gelman et al. (2014) book "Bayesian Data Analysis", or
+in [this article](https://arxiv.org/abs/1903.08008).
 """
 function ess(
-    chn::Chains;
-    sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-    showall=false,
+    chains::Chains;
+    sections = :parameters,
     kwargs...
 )
-    _chn = showall ? chn : Chains(chn, sections)
-    nt = merge((parameters = names(_chn),), ess(_chn.value.data; kwargs...))
-	return ChainDataFrame("ESS", nt; digits=digits)
+    # Subset the chain.
+    _chains = Chains(chains, _clean_sections(chains, sections))
+
+    # Compute the ESS.
+    nt = merge((parameters = names(_chains),), ess(_chains.value.data; kwargs...))
+
+	  return ChainDataFrame("ESS", nt)
 end
 
 function ess(
@@ -350,7 +335,7 @@ function ess(
 
         ess[i] = (n*m) / (-1 + 2*sum(P_monotone))
     end
-    
+
     return (ess = ess, rhat = Rhat)
 end
 
@@ -363,74 +348,71 @@ function _autocorrelation(x::AbstractVector, k::Integer, v = var(x), kwargs...)
 end
 
 """
-    summarystats(chn;
-        append_chains=true,
-        showall=false,
-        sections=[:parameters],
-        args...)
+    summarystats(chains[;
+                 sections = :parameters, append_chains = true, maxlag = 250, etype = :bm,
+                 kwargs...])
 
-Computes the mean, standard deviation, naive standard error, Monte Carlo standard error,
-and effective sample size for each parameter in the chain. Setting `append_chains=false`
-will return a vector of dataframes containing the summary statistics for each chain.
-`args...` is passed to the `msce` function.
+Compute the mean, standard deviation, naive standard error, Monte Carlo standard error,
+and effective sample size for each parameter in the chain.
+
+Setting `append_chains=false` will return a vector of dataframes containing the summary
+statistics for each chain.
+
+The remaining keyword arguments are passed to the `msce` function.
 """
-function summarystats(chn::Chains;
-        append_chains::Bool=true,
-        showall::Bool=false,
-        sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-        etype=:bm,
-        args...
-    )
-
+function summarystats(
+    chains::Chains;
+    sections = :parameters,
+    append_chains::Bool = true,
+    maxlag = 250,
+    etype = :bm,
+    kwargs...
+)
     # Make some functions.
     df_mcse(x) = length(x) < 200 ?
         missing :
-        mcse(cskip(x), etype, args...)
+        mcse(cskip(x), etype; kwargs...)
 
     # Store everything.
     funs = [mean∘cskip, std∘cskip, sem∘cskip, df_mcse]
     func_names = [:mean, :std, :naive_se, :mcse]
 
+    # Subset the chain.
+    _chains = Chains(chains, _clean_sections(chains, sections))
+
     # Caluclate ESS separately.
-    ess_df = ess(chn, sections=sections, showall=showall)
+    ess_df = ess(_chains; sections = nothing, maxlag = maxlag)
 
     # Summarize.
-    summary_df = summarize(chn, funs...;
-        func_names=func_names,
-        showall=showall,
-        sections=sections,
-        name="Summary Statistics",
+    summary_df = summarize(
+        _chains, funs...;
+        func_names = func_names,
+        append_chains = append_chains,
         additional_df = ess_df,
-        append_chains=append_chains)
+        name = "Summary Statistics",
+        sections = nothing
+    )
 
     return summary_df
 end
 
 """
-    mean(chn::Chains[, params];
-            append_chains::Bool=true,
-            showall::Bool=false,
-            sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-            args...)
+    mean(chains[, params; kwargs...])
 
-Calculates the mean of a `Chains` object, or a specific parameter.
+Calculate the mean of a chain.
 """
-function mean(chn::Chains;
-        append_chains::Bool=true,
-        showall::Bool=false,
-        sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-        args...
-    )
+function mean(chains::Chains; kwargs...)
     # Store everything.
     funs = [mean∘cskip]
     func_names = [:mean]
 
     # Summarize.
-    summary_df = summarize(chn, funs...;
-        func_names=func_names,
-        showall=showall,
-        sections=sections,
-        name="Mean")
+    summary_df = summarize(
+        chains, funs...;
+        func_names = func_names,
+        name = "Mean",
+        kwargs...
+    )
 
     return summary_df
 end

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -30,7 +30,7 @@ function autocor(
 end
 
 """
-    cor(chains[; sections = :parameters, append_chains = true, kwargs...])
+    cor(chains[; sections, append_chains = true, kwargs...])
 
 Compute the Pearson correlation matrix for the chain.
 
@@ -39,7 +39,7 @@ matrix for each chain.
 """
 function cor(
     chains::Chains;
-    sections = :parameters,
+    sections = _default_sections(chains),
     append_chains = true,
     kwargs...
 )
@@ -76,7 +76,7 @@ function chaindataframe_cor(name, names_of_params, chains::AbstractMatrix; kwarg
 end
 
 """
-    changerate(chains[; sections = :parameters, append_chains = true, kwargs...])
+    changerate(chains[; sections, append_chains = true, kwargs...])
 
 Compute the change rate for the chain.
 
@@ -85,7 +85,7 @@ rates for each chain.
 """
 function changerate(
     chains::Chains{<:Real};
-    sections = :parameters,
+    sections = _default_sections(chains),
     append_chains = true,
     kwargs...
 )
@@ -220,7 +220,7 @@ function quantile(
 end
 
 """
-	  ess(chn::Chains[;	sections = :parameters, kwargs...])
+	  ess(chn::Chains[;	sections, kwargs...])
 
 Compute the effective sample size (ESS) of a chain.
 
@@ -229,7 +229,7 @@ in [this article](https://arxiv.org/abs/1903.08008).
 """
 function ess(
     chains::Chains;
-    sections = :parameters,
+    sections = _default_sections(chains),
     kwargs...
 )
     # Subset the chain.
@@ -349,8 +349,7 @@ end
 
 """
     summarystats(chains[;
-                 sections = :parameters, append_chains = true, maxlag = 250, etype = :bm,
-                 kwargs...])
+                 sections, append_chains = true, maxlag = 250, etype = :bm, kwargs...])
 
 Compute the mean, standard deviation, naive standard error, Monte Carlo standard error,
 and effective sample size for each parameter in the chain.
@@ -362,7 +361,7 @@ The remaining keyword arguments are passed to the `msce` function.
 """
 function summarystats(
     chains::Chains;
-    sections = :parameters,
+    sections = _default_sections(chains),
     append_chains::Bool = true,
     maxlag = 250,
     etype = :bm,

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -158,26 +158,21 @@ Summarize method for a Chains object.
 ```
 
 """
-function summarize(chains::Chains, funs...;
-        sections::Union{Symbol, Vector{Symbol}}=Symbol[:parameters],
-        func_names::AbstractVector{Symbol} = Symbol[],
-        append_chains::Bool=true,
-        showall::Bool=false,
-        name::String="",
-        additional_df=nothing,
+function summarize(
+    chains::Chains, funs...;
+    sections = :parameters,
+    func_names::AbstractVector{Symbol} = Symbol[],
+    append_chains::Bool = true,
+    name::String = "",
+    additional_df = nothing
 )
-    # Check that we actually have :parameters.
-    showall = showall || !in(:parameters, keys(chains.name_map))
-    
-    # If we weren't given any functions, fall back on summary stats.
-    if length(funs) == 0
-        return summarystats(chains,
-            sections=sections,
-            showall=showall)
+    # If we weren't given any functions, fall back to summary stats.
+    if isempty(funs)
+        return summarystats(chains; sections = sections)
     end
-    
+
     # Generate a chain to work on.
-    chn = Chains(chains, sections)
+    chn = Chains(chains, _clean_sections(chains, sections))
 
     # Obtain names of parameters.
     names_of_params = names(chn)

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -121,46 +121,20 @@ function Base.convert(::Type{Array}, cs::Array{C,1}) where C<:ChainDataFrame
 end
 
 """
+    summarize(chains, funs...[; sections, func_names = [], etype = :bm])
 
-# Summarize a Chains object formatted as a ChainsDataFrame
+Summarize `chains` in a `ChainsDataFrame`.
 
-Summarize method for a Chains object.
+# Examples
 
-### Method
-```julia
-  summarize(
-    chn::Chains,
-    funs...;
-    sections::Vector{Symbol}=[:parameters],
-    func_names=[],
-    etype=:bm
-  )
-```
-
-### Required arguments
-```julia
-* `chn` : Chains object to convert to a ChainsDataFrame-formatted summary
-```
-
-### Optional arguments
-```julia
-* `funs...` : zero or more vector functions, e.g. mean, std, etc.
-* `sections = [:parameters]` : Sections from the Chains object to be included
-* `etype = :bm` : Default for df_mcse
-```
-
-### Examples
-```julia
 * `summarize(chns)` : Complete chain summary
 * `summarize(chns[[:parm1, :parm2]])` : Chain summary of selected parameters
-* `summarize(chns, sections=[:parameters])`  : Chain summary of :parameters section
-* `summarize(chns, sections=[:parameters, :internals])` : Chain summary for multiple sections
-```
-
+* `summarize(chns; sections=[:parameters])`  : Chain summary of :parameters section
+* `summarize(chns; sections=[:parameters, :internals])` : Chain summary for multiple sections
 """
 function summarize(
     chains::Chains, funs...;
-    sections = :parameters,
+    sections = _default_sections(chains),
     func_names::AbstractVector{Symbol} = Symbol[],
     append_chains::Bool = true,
     name::String = "",

--- a/test/arrayconstructor_tests.jl
+++ b/test/arrayconstructor_tests.jl
@@ -53,8 +53,7 @@ using MCMCChains, Test
         @test size(Array(chns, [:parameters])) == (d*c, main_params)
         @test size(Array(chns, [:parameters])) == size(Array(chns))
         @test size(Array(chns, [:parameters, :internals])) == (d*c, total_params)
-        @test size(Array(chns, [:parameters, :internals])) ==
-            size(Array(chns, showall=true))
+        @test size(Array(chns, [:parameters, :internals])) == size(Array(chns, nothing))
         @test size(Array(chns, [:internals])) == (d*c, internal_params)
         @test size(Array(chns, append_chains=true)) == (d*c, main_params)
         @test size(Array(chns, append_chains=false)) == (5,)

--- a/test/missing_tests.jl
+++ b/test/missing_tests.jl
@@ -20,14 +20,14 @@ end
     chn = Chains(randn(1000, 2, 2))
 
     # Call describe without missing values.
-    describe(devnull, chn; showall=true)
+    describe(devnull, chn; sections = nothing)
     s1, s2 = summarystats(chn), quantile(chn)
 
     # Add missing values.
     chn_m = Chains(cat(chn.value, ones(1, 2, 2) .* missing, dims = 1))
 
     # Call describe with missing values.
-    describe(devnull, chn_m; showall=true)
+    describe(devnull, chn_m; sections = nothing)
     m1, m2 = summarystats(chn_m), quantile(chn_m)
 
     @test testdiff(s1, m1)
@@ -58,5 +58,5 @@ end
         @test testdiff(rf_1, rf_2)
     end
 
-    @test_throws AssertionError discretediag(chn_m)
+    @test_throws MethodError discretediag(chn_m)
 end


### PR DESCRIPTION
This PR removes the `showall` keyword argument, instead one has to specify `sections = nothing` now. Moreover, somehow the previously merged PR reintroduced some `digits` keyword arguments which are removed in this PR as well.