### PR TITLE
Change convert(::Type{Array}, ::Vector{<:ChainDataFrame}) to the

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "Chain types and utility functions for MCMC simulations."
-version = "4.0.2"
+version = "4.0.3"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -106,7 +106,7 @@ end
 function Base.convert(::Type{Array}, c::C) where C<:ChainDataFrame
     T = promote_eltype_namedtuple_tail(c.nt)
     arr = Array{T, 2}(undef, c.nrows, c.ncols - 1)
-    
+
     for (i, k) in enumerate(Iterators.drop(keys(c.nt), 1))
         arr[:, i] = c.nt[k]
     end
@@ -114,8 +114,7 @@ function Base.convert(::Type{Array}, c::C) where C<:ChainDataFrame
     return arr
 end
 
-Base.convert(::Type{Array{ChainDataFrame,1}}, cs::Array{ChainDataFrame,1}) = cs
-function Base.convert(::Type{Array}, cs::Array{C,1}) where C<:ChainDataFrame
+function Base.convert(::Type{Array}, cs::Array{ChainDataFrame{T},1}) where T<:NamedTuple
     return mapreduce((x, y) -> cat(x, y; dims = Val(3)), cs) do c
         reshape(convert(Array, c), Val(3))
     end


### PR DESCRIPTION
internal _to_matrix function since the source is already an Array
so the operation should really be a noop. Furthermore, the implied
type piracy causes issues in other packages.

Closes #233 