### PR TITLE
Return `missing` in `mcse_bm` instead of throwing an error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "Chain types and utility functions for MCMC simulations."
-version = "4.0.3"
+version = "4.0.4"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/mcse.jl
+++ b/src/mcse.jl
@@ -11,9 +11,8 @@ function mcse_bm(x::Vector{<:Real}; size::Integer=100)
     n = length(x)
     m = div(n, size)
     if m < 2
-        throw(
-         ArgumentError("iterations are < $(2 * size) and batch size is > $(div(n, 2))")
-        )
+        @debug "iterations are < $(2 * size) and batch size is > $(div(n, 2))"
+        return missing
     end
     mbar = [mean(x[i * size .+ (1:size)]) for i in 0:(m - 1)]
     return sem(mbar)

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -248,13 +248,8 @@ function summarystats(
     etype = :bm,
     kwargs...
 )
-    # Make some functions.
-    df_mcse(x) = length(x) < 200 ?
-        missing :
-        mcse(cskip(x), etype; kwargs...)
-
     # Store everything.
-    funs = [mean∘cskip, std∘cskip, sem∘cskip, df_mcse]
+    funs = [mean∘cskip, std∘cskip, sem∘cskip, x -> mcse(cskip(x), etype; kwargs...)]
     func_names = [:mean, :std, :naive_se, :mcse]
 
     # Subset the chain.


### PR DESCRIPTION
This PR handles chains with a small number of non-missing samples in a nicer way. Similar to ESS, no error
is thrown but `missing` is returned. The previous check was not sufficient since it was not based on
the number of non-missing samples but on the number of all samples.