### PR TITLE
Fix deprecated `read` and `write`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "Chain types and utility functions for MCMC simulations."
-version = "4.2.1"
+version = "4.2.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -79,23 +79,27 @@ include("rstar.jl")
 
 # deprecations
 # TODO: Remove dependency on Serialization if this deprecation is removed
+# somehow `@deprecate` doesn't work with qualified function names,
+# so we use the following hack
+const _read = Base.read
+const _write = Base.write
 @static if VERSION < v"1.1"
-    Base.@deprecate read(
+    Base.@deprecate _read(
         f::AbstractString,
         ::Type{T}
     ) where {T<:Chains} open(Serialization.deserialize, f, "r") false
-    Base.@deprecate write(
+    Base.@deprecate _write(
         f::AbstractString,
         c::Chains
     ) open(f, "w") do io
         Serialization.serialize(io, c)
     end false
 else
-    Base.@deprecate read(
+    Base.@deprecate _read(
         f::AbstractString,
         ::Type{T}
     ) where {T<:Chains} Serialization.deserialize(f) false
-    Base.@deprecate write(
+    Base.@deprecate _write(
         f::AbstractString,
         c::Chains
     ) Serialization.serialize(f, c) false


### PR DESCRIPTION
Fixes a bug introducing when deprecating `read` and `write`. Instead of overloading Base.read and Base.write we accidentally added new MCMCChains.read and MCMCChains.write methods.