### PR TITLE
Fix ChainDataFrame indexing with Colon

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "Chain types and utility functions for MCMC simulations."
-version = "4.2.2"
+version = "4.2.3"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -39,7 +39,7 @@ function Base.getindex(c::ChainDataFrame, s::Union{Colon, Integer, UnitRange}, g
     convert(Array, getindex(c, c.nt[:parameters][s], collect(keys(c.nt))[g]))
 end
 
-Base.getindex(c::ChainDataFrame, s::Union{Symbol, Vector{Symbol}}, g::Colon) = getindex(c, s)
+Base.getindex(c::ChainDataFrame, s::Vector{Symbol}, ::Colon) = getindex(c, s)
 function Base.getindex(c::ChainDataFrame, s::Union{Symbol, Vector{Symbol}})
     getindex(c, s, collect(keys(c.nt)))
 end

--- a/src/summarize.jl
+++ b/src/summarize.jl
@@ -39,10 +39,7 @@ function Base.getindex(c::ChainDataFrame, s::Union{Colon, Integer, UnitRange}, g
     convert(Array, getindex(c, c.nt[:parameters][s], collect(keys(c.nt))[g]))
 end
 
-function Base.getindex(c::ChainDataFrame, s::Union{Symbol, Vector{Symbol}}, g::Colon)
-    getindex(c, c.nt[:parameters], collect(keys(c.nt)))
-end
-
+Base.getindex(c::ChainDataFrame, s::Union{Symbol, Vector{Symbol}}, g::Colon) = getindex(c, s)
 function Base.getindex(c::ChainDataFrame, s::Union{Symbol, Vector{Symbol}})
     getindex(c, s, collect(keys(c.nt)))
 end

--- a/test/summarize_tests.jl
+++ b/test/summarize_tests.jl
@@ -13,7 +13,11 @@ using Statistics: std
 
     @test 0.48 < parm_df[:a, :mean][1] < 0.52
     @test names(parm_df) == [:parameters, :mean, :std, :naive_se, :mcse, :ess, :rhat]
-    @test parm_df[:a, :] == parm_df[:a]
+
+    # Indexing tests
+    @test convert(Array, parm_df[:a, :]) == convert(Array, parm_df[:a])
+    @test parm_df[:a, :][:,:parameters] == :a
+    @test parm_df[[:a, :b], :][:,:parameters] == [:a, :b]
 
     all_sections_df = summarize(chns, sections=[:parameters, :internals])
     @test all_sections_df[:,:parameters] == [:a, :b, :c, :d, :e, :f, :g, :h]

--- a/test/summarize_tests.jl
+++ b/test/summarize_tests.jl
@@ -13,6 +13,7 @@ using Statistics: std
 
     @test 0.48 < parm_df[:a, :mean][1] < 0.52
     @test names(parm_df) == [:parameters, :mean, :std, :naive_se, :mcse, :ess, :rhat]
+    @test parm_df[:a, :] == parm_df[:a]
 
     all_sections_df = summarize(chns, sections=[:parameters, :internals])
     @test all_sections_df[:,:parameters] == [:a, :b, :c, :d, :e, :f, :g, :h]


### PR DESCRIPTION
Fixes #244. The buggy function was actually identical to the one below it, so I just mapped them together.