### PR TITLE
Fix implementation of Tables row interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "Chain types and utility functions for MCMC simulations."
-version = "4.7.1"
+version = "4.7.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -43,12 +43,6 @@ Tables.rowaccess(::Type{<:Chains}) = true
 
 Tables.rows(chn::Chains) = Tables.rows(Tables.columntable(chn))
 
-Tables.rowtable(chn::Chains) = Tables.rowtable(Tables.columntable(chn))
-
-function Tables.namedtupleiterator(chn::Chains)
-    return Tables.namedtupleiterator(Tables.columntable(chn))
-end
-
 function Tables.schema(chn::Chains)
     _check_columnnames(chn)
     nms = Tables.columnnames(chn)
@@ -80,12 +74,6 @@ Tables.getcolumn(cdf::ChainDataFrame, nm::Symbol) = cdf.nt[nm]
 Tables.rowaccess(::Type{<:ChainDataFrame}) = true
 
 Tables.rows(cdf::ChainDataFrame) = Tables.rows(Tables.columntable(cdf))
-
-Tables.rowtable(cdf::ChainDataFrame) = Tables.rowtable(Tables.columntable(cdf))
-
-function Tables.namedtupleiterator(cdf::ChainDataFrame)
-    return Tables.namedtupleiterator(Tables.columntable(cdf))
-end
 
 function Tables.schema(::ChainDataFrame{NamedTuple{names,T}}) where {names,T}
     types = ntuple(i -> eltype(fieldtype(T, i)), fieldcount(T))

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -41,10 +41,7 @@ end
 
 Tables.rowaccess(::Type{<:Chains}) = true
 
-function Tables.rows(chn::Chains)
-    _check_columnnames(chn)
-    return chn
-end
+Tables.rows(chn::Chains) = Tables.rows(Tables.columntable(chn))
 
 Tables.rowtable(chn::Chains) = Tables.rowtable(Tables.columntable(chn))
 
@@ -82,7 +79,7 @@ Tables.getcolumn(cdf::ChainDataFrame, nm::Symbol) = cdf.nt[nm]
 
 Tables.rowaccess(::Type{<:ChainDataFrame}) = true
 
-Tables.rows(cdf::ChainDataFrame) = cdf
+Tables.rows(cdf::ChainDataFrame) = Tables.rows(Tables.columntable(cdf))
 
 Tables.rowtable(cdf::ChainDataFrame) = Tables.rowtable(Tables.columntable(cdf))
 

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -1,6 +1,8 @@
 # Tables and TableTraits interface
 
-## Chains
+####
+#### Chains
+####
 
 function _check_columnnames(chn::Chains)
     for name in names(chn)
@@ -11,7 +13,11 @@ function _check_columnnames(chn::Chains)
     end
 end
 
+#### Tables interface
+
 Tables.istable(::Type{<:Chains}) = true
+
+# AbstractColumns interface
 
 Tables.columnaccess(::Type{<:Chains}) = true
 
@@ -39,9 +45,13 @@ function Tables.getcolumn(chn::Chains, nm::Symbol)
     end
 end
 
+# row access
+
 Tables.rowaccess(::Type{<:Chains}) = true
 
 Tables.rows(chn::Chains) = Tables.rows(Tables.columntable(chn))
+
+# optional Tables overloads
 
 function Tables.schema(chn::Chains)
     _check_columnnames(chn)
@@ -51,6 +61,8 @@ function Tables.schema(chn::Chains)
     return Tables.Schema(nms, types)
 end
 
+#### TableTraits interface
+
 IteratorInterfaceExtensions.isiterable(::Chains) = true
 function IteratorInterfaceExtensions.getiterator(chn::Chains)
     return Tables.datavaluerows(Tables.columntable(chn))
@@ -58,9 +70,15 @@ end
 
 TableTraits.isiterabletable(::Chains) = true
 
-## ChainDataFrame
+####
+#### ChainDataFrame
+####
+
+#### Tables interface
 
 Tables.istable(::Type{<:ChainDataFrame}) = true
+
+# AbstractColumns interface
 
 Tables.columnaccess(::Type{<:ChainDataFrame}) = true
 
@@ -71,6 +89,8 @@ Tables.columnnames(::ChainDataFrame{<:NamedTuple{names}}) where {names} = names
 Tables.getcolumn(cdf::ChainDataFrame, i::Int) = cdf.nt[i]
 Tables.getcolumn(cdf::ChainDataFrame, nm::Symbol) = cdf.nt[nm]
 
+# row access
+
 Tables.rowaccess(::Type{<:ChainDataFrame}) = true
 
 Tables.rows(cdf::ChainDataFrame) = Tables.rows(Tables.columntable(cdf))
@@ -79,6 +99,8 @@ function Tables.schema(::ChainDataFrame{NamedTuple{names,T}}) where {names,T}
     types = ntuple(i -> eltype(fieldtype(T, i)), fieldcount(T))
     return Tables.Schema(names, types)
 end
+
+#### TableTraits interface
 
 IteratorInterfaceExtensions.isiterable(::ChainDataFrame) = true
 function IteratorInterfaceExtensions.getiterator(cdf::ChainDataFrame)

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -26,11 +26,11 @@ function Tables.getcolumn(chn::Chains, i::Int)
     return Tables.getcolumn(chn, Tables.columnnames(chn)[i])
 end
 function Tables.getcolumn(chn::Chains, nm::Symbol)
-    if nm == :iteration
+    if nm === :iteration
         iterations = range(chn)
         nchains = size(chn, 3)
         return repeat(iterations, nchains)
-    elseif nm == :chain
+    elseif nm === :chain
         chainids = chains(chn)
         niter = size(chn, 1)
         return repeat(chainids; inner = niter)

--- a/test/tables_tests.jl
+++ b/test/tables_tests.jl
@@ -33,7 +33,6 @@ using DataFrames
             @test_throws Exception Tables.getcolumn(chn, :i)
             @test_throws Exception Tables.getcolumn(chn, 11)
             @test Tables.rowaccess(typeof(chn))
-            @test Tables.rows(chn) === chn
             @test length(Tables.rowtable(chn)) == 4000
             nt = Tables.rowtable(chn)[1]
             @test nt ==
@@ -117,7 +116,6 @@ using DataFrames
             @test_throws Exception Tables.getcolumn(cdf, :blah)
             @test_throws Exception Tables.getcolumn(cdf, length(cdf.nt) + 1)
             @test Tables.rowaccess(typeof(cdf))
-            @test Tables.rows(cdf) === cdf
             @test length(Tables.rowtable(cdf)) == length(cdf.nt[1])
             @test Tables.columntable(cdf) == cdf.nt
             nt = Tables.rowtable(cdf)[1]

--- a/test/tables_tests.jl
+++ b/test/tables_tests.jl
@@ -59,6 +59,7 @@ using DataFrames
             )
             @test Tables.matrix(chn[:, :, 1])[:, 3:end] ≈ chn[:, :, 1].value
             @test Tables.matrix(chn[:, :, 2])[:, 3:end] ≈ chn[:, :, 2].value
+            @test Tables.matrix(Tables.rowtable(chn)) == Tables.matrix(Tables.columntable(chn))
 
             val = rand(1000, 2, 4)
             chn2 = Chains(val, ["iteration", "a"])
@@ -127,6 +128,7 @@ using DataFrames
             @test Tables.schema(cdf) isa Tables.Schema
             @test Tables.schema(cdf).names === keys(cdf.nt)
             @test Tables.schema(cdf).types === eltype.(values(cdf.nt))
+            @test Tables.matrix(Tables.rowtable(cdf)) == Tables.matrix(Tables.columntable(cdf))
         end
 
         @testset "TableTraits interface" begin

--- a/test/tables_tests.jl
+++ b/test/tables_tests.jl
@@ -38,6 +38,24 @@ using DataFrames
 
             @testset "row access" begin
                 @test Tables.rowaccess(typeof(chn))
+                @test Tables.rows(chn) isa Tables.RowIterator
+                @test eltype(Tables.rows(chn)) <: Tables.AbstractRow
+                rows = collect(Tables.rows(chn))
+                @test eltype(rows) <: Tables.AbstractRow
+                @test size(rows) === (4000,)
+                for chainid in 1:4, iterid in 1:1000
+                    row = rows[(chainid - 1) * 1000 + iterid]
+                    @test Tables.columnnames(row) ==
+                        (:iteration, :chain, :a, :b, :c, :d, :e, :f, :g, :h)
+                    @test Tables.getcolumn(row, 1) == iterid
+                    @test Tables.getcolumn(row, 2) == chainid
+                    @test Tables.getcolumn(row, 3) == chn[iterid, :a, chainid]
+                    @test Tables.getcolumn(row, 10) == chn[iterid, :h, chainid]
+                    @test Tables.getcolumn(row, :iteration) == iterid
+                    @test Tables.getcolumn(row, :chain) == chainid
+                    @test Tables.getcolumn(row, :a) == chn[iterid, :a, chainid]
+                    @test Tables.getcolumn(row, :h) == chn[iterid, :h, chainid]
+                end
             end
 
             @testset "integration tests" begin
@@ -136,6 +154,19 @@ using DataFrames
 
             @testset "row access" begin
                 @test Tables.rowaccess(typeof(cdf))
+                @test Tables.rows(cdf) isa Tables.RowIterator
+                @test eltype(Tables.rows(cdf)) <: Tables.AbstractRow
+                rows = collect(Tables.rows(cdf))
+                @test eltype(rows) <: Tables.AbstractRow
+                @test size(rows) === (2,)
+                @testset for i in 1:2
+                    row = rows[i]
+                    @test Tables.columnnames(row) == keys(cdf.nt)
+                    for j in length(cdf.nt)
+                        @test Tables.getcolumn(row, j) == cdf.nt[j][i]
+                        @test Tables.getcolumn(row, keys(cdf.nt)[j]) == cdf.nt[j][i]
+                    end
+                end
             end
 
             @testset "integration tests" begin

--- a/test/tables_tests.jl
+++ b/test/tables_tests.jl
@@ -13,63 +13,77 @@ using DataFrames
 
         @testset "Tables interface" begin
             @test Tables.istable(typeof(chn))
-            @test Tables.columnaccess(typeof(chn))
-            @test Tables.columns(chn) === chn
-            @test Tables.columnnames(chn) ==
-                  (:iteration, :chain, :a, :b, :c, :d, :e, :f, :g, :h)
-            @test Tables.getcolumn(chn, :iteration) == [1:1000; 1:1000; 1:1000; 1:1000]
-            @test Tables.getcolumn(chn, :chain) ==
-                  [fill(1, 1000); fill(2, 1000); fill(3, 1000); fill(4, 1000)]
-            @test Tables.getcolumn(chn, :a) == [
-                vec(chn[:, :a, 1])
-                vec(chn[:, :a, 2])
-                vec(chn[:, :a, 3])
-                vec(chn[:, :a, 4])
-            ]
-            @test_throws Exception Tables.getcolumn(chn, :j)
-            @test Tables.getcolumn(chn, 1) == Tables.getcolumn(chn, :iteration)
-            @test Tables.getcolumn(chn, 2) == Tables.getcolumn(chn, :chain)
-            @test Tables.getcolumn(chn, 3) == Tables.getcolumn(chn, :a)
-            @test_throws Exception Tables.getcolumn(chn, :i)
-            @test_throws Exception Tables.getcolumn(chn, 11)
-            @test Tables.rowaccess(typeof(chn))
-            @test length(Tables.rowtable(chn)) == 4000
-            nt = Tables.rowtable(chn)[1]
-            @test nt ==
-                  (; (k => Tables.getcolumn(chn, k)[1] for k in Tables.columnnames(chn))...)
-            @test nt == collect(Iterators.take(Tables.namedtupleiterator(chn), 1))[1]
-            nt = Tables.rowtable(chn)[2]
-            @test nt ==
-                  (; (k => Tables.getcolumn(chn, k)[2] for k in Tables.columnnames(chn))...)
-            @test nt == collect(Iterators.take(Tables.namedtupleiterator(chn), 2))[2]
-            @test Tables.schema(chn) isa Tables.Schema
-            @test Tables.schema(chn).names ===
-                  (:iteration, :chain, :a, :b, :c, :d, :e, :f, :g, :h)
-            @test Tables.schema(chn).types === (
-                Int,
-                Int,
-                Float64,
-                Float64,
-                Float64,
-                Float64,
-                Float64,
-                Float64,
-                Float64,
-                Float64,
-            )
-            @test Tables.matrix(chn[:, :, 1])[:, 3:end] ≈ chn[:, :, 1].value
-            @test Tables.matrix(chn[:, :, 2])[:, 3:end] ≈ chn[:, :, 2].value
-            @test Tables.matrix(Tables.rowtable(chn)) == Tables.matrix(Tables.columntable(chn))
 
-            val = rand(1000, 2, 4)
-            chn2 = Chains(val, ["iteration", "a"])
-            @test_throws Exception Tables.columns(chn2)
-            @test_throws Exception Tables.rows(chn2)
-            @test_throws Exception Tables.schema(chn2)
-            chn3 = Chains(val, ["chain", "a"])
-            @test_throws Exception Tables.columns(chn3)
-            @test_throws Exception Tables.rows(chn3)
-            @test_throws Exception Tables.schema(chn3)
+            @testset "column access" begin
+                @test Tables.columnaccess(typeof(chn))
+                @test Tables.columns(chn) === chn
+                @test Tables.columnnames(chn) ==
+                    (:iteration, :chain, :a, :b, :c, :d, :e, :f, :g, :h)
+                @test Tables.getcolumn(chn, :iteration) == [1:1000; 1:1000; 1:1000; 1:1000]
+                @test Tables.getcolumn(chn, :chain) ==
+                    [fill(1, 1000); fill(2, 1000); fill(3, 1000); fill(4, 1000)]
+                @test Tables.getcolumn(chn, :a) == [
+                    vec(chn[:, :a, 1])
+                    vec(chn[:, :a, 2])
+                    vec(chn[:, :a, 3])
+                    vec(chn[:, :a, 4])
+                ]
+                @test_throws Exception Tables.getcolumn(chn, :j)
+                @test Tables.getcolumn(chn, 1) == Tables.getcolumn(chn, :iteration)
+                @test Tables.getcolumn(chn, 2) == Tables.getcolumn(chn, :chain)
+                @test Tables.getcolumn(chn, 3) == Tables.getcolumn(chn, :a)
+                @test_throws Exception Tables.getcolumn(chn, :i)
+                @test_throws Exception Tables.getcolumn(chn, 11)
+            end
+
+            @testset "row access" begin
+                @test Tables.rowaccess(typeof(chn))
+            end
+
+            @testset "integration tests" begin
+                @test length(Tables.rowtable(chn)) == 4000
+                nt = Tables.rowtable(chn)[1]
+                @test nt ==
+                    (; (k => Tables.getcolumn(chn, k)[1] for k in Tables.columnnames(chn))...)
+                @test nt == collect(Iterators.take(Tables.namedtupleiterator(chn), 1))[1]
+                nt = Tables.rowtable(chn)[2]
+                @test nt ==
+                    (; (k => Tables.getcolumn(chn, k)[2] for k in Tables.columnnames(chn))...)
+                @test nt == collect(Iterators.take(Tables.namedtupleiterator(chn), 2))[2]
+                @test Tables.matrix(chn[:, :, 1])[:, 3:end] ≈ chn[:, :, 1].value
+                @test Tables.matrix(chn[:, :, 2])[:, 3:end] ≈ chn[:, :, 2].value
+                @test Tables.matrix(Tables.rowtable(chn)) == Tables.matrix(Tables.columntable(chn))
+            end
+
+            @testset "schema" begin
+                @test Tables.schema(chn) isa Tables.Schema
+                @test Tables.schema(chn).names ===
+                    (:iteration, :chain, :a, :b, :c, :d, :e, :f, :g, :h)
+                @test Tables.schema(chn).types === (
+                    Int,
+                    Int,
+                    Float64,
+                    Float64,
+                    Float64,
+                    Float64,
+                    Float64,
+                    Float64,
+                    Float64,
+                    Float64,
+                )
+            end
+
+            @testset "exceptions raised if reserved colname used" begin
+                val2 = rand(1000, 2, 4)
+                chn2 = Chains(val2, ["iteration", "a"])
+                @test_throws Exception Tables.columns(chn2)
+                @test_throws Exception Tables.rows(chn2)
+                @test_throws Exception Tables.schema(chn2)
+                chn3 = Chains(val2, ["chain", "a"])
+                @test_throws Exception Tables.columns(chn3)
+                @test_throws Exception Tables.rows(chn3)
+                @test_throws Exception Tables.schema(chn3)
+            end
         end
 
         @testset "TableTraits interface" begin
@@ -82,10 +96,10 @@ using DataFrames
             @test nt ==
                   (; (k => Tables.getcolumn(chn, k)[2] for k in Tables.columnnames(chn))...)
 
-            val = rand(1000, 2, 4)
-            chn2 = Chains(val, ["iteration", "a"])
+            val2 = rand(1000, 2, 4)
+            chn2 = Chains(val2, ["iteration", "a"])
             @test_throws Exception IteratorInterfaceExtensions.getiterator(chn2)
-            chn3 = Chains(val, ["chain", "a"])
+            chn3 = Chains(val2, ["chain", "a"])
             @test_throws Exception IteratorInterfaceExtensions.getiterator(chn3)
         end
 
@@ -106,29 +120,41 @@ using DataFrames
 
         @testset "Tables interface" begin
             @test Tables.istable(typeof(cdf))
-            @test Tables.columnaccess(typeof(cdf))
-            @test Tables.columns(cdf) === cdf
-            @test Tables.columnnames(cdf) == keys(cdf.nt)
-            for (k, v) in pairs(cdf.nt)
-                @test Tables.getcolumn(cdf, k) == v
+
+            @testset "column access" begin
+                @test Tables.columnaccess(typeof(cdf))
+                @test Tables.columns(cdf) === cdf
+                @test Tables.columnnames(cdf) == keys(cdf.nt)
+                for (k, v) in pairs(cdf.nt)
+                    @test Tables.getcolumn(cdf, k) == v
+                end
+                @test Tables.getcolumn(cdf, 1) == Tables.getcolumn(cdf, keys(cdf.nt)[1])
+                @test Tables.getcolumn(cdf, 2) == Tables.getcolumn(cdf, keys(cdf.nt)[2])
+                @test_throws Exception Tables.getcolumn(cdf, :blah)
+                @test_throws Exception Tables.getcolumn(cdf, length(cdf.nt) + 1)
             end
-            @test Tables.getcolumn(cdf, 1) == Tables.getcolumn(cdf, keys(cdf.nt)[1])
-            @test Tables.getcolumn(cdf, 2) == Tables.getcolumn(cdf, keys(cdf.nt)[2])
-            @test_throws Exception Tables.getcolumn(cdf, :blah)
-            @test_throws Exception Tables.getcolumn(cdf, length(cdf.nt) + 1)
-            @test Tables.rowaccess(typeof(cdf))
-            @test length(Tables.rowtable(cdf)) == length(cdf.nt[1])
-            @test Tables.columntable(cdf) == cdf.nt
-            nt = Tables.rowtable(cdf)[1]
-            @test nt == (; (k => v[1] for (k, v) in pairs(cdf.nt))...)
-            @test nt == collect(Iterators.take(Tables.namedtupleiterator(cdf), 1))[1]
-            nt = Tables.rowtable(cdf)[2]
-            @test nt == (; (k => v[2] for (k, v) in pairs(cdf.nt))...)
-            @test nt == collect(Iterators.take(Tables.namedtupleiterator(cdf), 2))[2]
-            @test Tables.schema(cdf) isa Tables.Schema
-            @test Tables.schema(cdf).names === keys(cdf.nt)
-            @test Tables.schema(cdf).types === eltype.(values(cdf.nt))
-            @test Tables.matrix(Tables.rowtable(cdf)) == Tables.matrix(Tables.columntable(cdf))
+
+            @testset "row access" begin
+                @test Tables.rowaccess(typeof(cdf))
+            end
+
+            @testset "integration tests" begin
+                @test length(Tables.rowtable(cdf)) == length(cdf.nt[1])
+                @test Tables.columntable(cdf) == cdf.nt
+                nt = Tables.rowtable(cdf)[1]
+                @test nt == (; (k => v[1] for (k, v) in pairs(cdf.nt))...)
+                @test nt == collect(Iterators.take(Tables.namedtupleiterator(cdf), 1))[1]
+                nt = Tables.rowtable(cdf)[2]
+                @test nt == (; (k => v[2] for (k, v) in pairs(cdf.nt))...)
+                @test nt == collect(Iterators.take(Tables.namedtupleiterator(cdf), 2))[2]
+                @test Tables.matrix(Tables.rowtable(cdf)) == Tables.matrix(Tables.columntable(cdf))
+            end
+
+            @testset "schema" begin
+                @test Tables.schema(cdf) isa Tables.Schema
+                @test Tables.schema(cdf).names === keys(cdf.nt)
+                @test Tables.schema(cdf).types === eltype.(values(cdf.nt))
+            end
         end
 
         @testset "TableTraits interface" begin


### PR DESCRIPTION
This PR fixes #268 and https://github.com/fonsp/Pluto.jl/issues/868 by correctly implementing `Tables.rows` in terms of `Tables.columntable`.

Because the optional interface methods `Tables.namedtupleiterator` and `Tables.rowtable` were previously implemented to forward to `Tables.columntable` instead of going through the default `Tables.rows` approach, with this change, they no longer are necessary to get the performance boost and have been removed.

Edit: I have verified that Pluto correctly displays `Chains` and `ChainDataFrame` objects with this PR.