### PR TITLE
Bump AxisArrays version (Fixes Julia 1.7)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 AbstractFFTs = "0.5, 1"
 AbstractMCMC = "0.4, 0.5, 1.0, 2.0, 3.0"
-AxisArrays = "0.4.2"
+AxisArrays = "0.4.4"
 Compat = "2.2, 3"
 Distributions = "0.21, 0.22, 0.23, 0.24, 0.25"
 Formatting = "0.4"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ Random.seed!(0)
 @testset "MCMCChains" begin
     # MLJXGBoostInterface requires Julia >= 1.3
     # XGBoost errors on 32bit systems: https://github.com/dmlc/XGBoost.jl/issues/92
-    if VERSION >= v"1.3" && Sys.WORD_SIZE == 64
+    if VERSION >= v"1.3" && VERSION < v"1.7" && Sys.WORD_SIZE == 64
         # run tests related to rstar statistic
         println("Rstar")
         Pkg.add("MLJBase")


### PR DESCRIPTION
AxisArrays works now on Julia 1.7 thanks to https://github.com/JuliaArrays/AxisArrays.jl/pull/201.