### PR TITLE
add docstring for `hpd`

### DIFF
--- a/docs/src/stats.md
+++ b/docs/src/stats.md
@@ -8,4 +8,5 @@ describe
 mean
 summarystats
 quantile
+hpd
 ```

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -205,6 +205,28 @@ function _hpd(x::AbstractVector{<:Real}; alpha::Real=0.05)
     return [a[i], b[i]]
 end
 
+"""
+    hpd(chn::Chains; alpha::Real=0.05, kwargs...)
+
+Return the highest posterior density interval representing `1-alpha` probability mass.
+
+Note that this will return a single interval and will not return multiple intervals for discontinuous regions.
+
+# Examples
+
+```julia-repl
+julia> val = rand(500, 2, 3);
+julia> chn = Chains(val, [:a, :b]);
+
+julia> hpd(chn)
+HPD
+  parameters     lower     upper 
+      Symbol   Float64   Float64 
+
+           a    0.0554    0.9944
+           b    0.0114    0.9460
+```
+"""
 function hpd(chn::Chains; alpha::Real=0.05, kwargs...)
     labels = [:lower, :upper]
     l(x) = _hpd(x, alpha=alpha)[1]


### PR DESCRIPTION
`hpd` is exported but there is no documentation for it. Please review the docstring for accuracy before merging.