### PR TITLE
Update rstar tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "Chain types and utility functions for MCMC simulations."
-version = "5.6.0"
+version = "5.6.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/test/rstar_tests.jl
+++ b/test/rstar_tests.jl
@@ -31,6 +31,6 @@ classif = DecisionTreeClassifier()
     chn_notmixed = Chains(val)
 
     # Restuling R value should be close to two, i.e. the classifier should be able to learn an almost perfect decision boundary between chains.
-    R = rstar(classif, chn_notmixed)
+    R = rstar(classif, chn_notmixed; split_chains=1)
     @test mean(R) ≈ 2 atol=0.1
 end


### PR DESCRIPTION
https://github.com/TuringLang/MCMCDiagnosticTools.jl/pull/52 updated `rstar` to by default split the chains in two to test for within-chain convergence. This causes the final `rstar` test to fail, so this PR updates the test to explicitly use no splitting.