### PR TITLE
Allow show to function properly even if some statistic computations fail

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "Chain types and utility functions for MCMC simulations."
-version = "6.0.0"
+version = "6.0.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/src/stats.jl
+++ b/src/stats.jl
@@ -321,6 +321,7 @@ function summarystats(
     try
         ess_rhat_rank_df = MCMCDiagnosticTools.ess_rhat(
             _chains; sections = nothing, autocov_method = autocov_method, maxlag = maxlag, kind=:rank
+        )
         nt_ess_rhat_rank = (
             ess_bulk=ess_rhat_rank_df.nt.ess,
             rhat=ess_rhat_rank_df.nt.rhat,


### PR DESCRIPTION
In some scenarios where the chain is producing weird values, we can easily run into issues with some of the statistics we compute in `show`, which means that `show` simply breaks. This can be both very annoying and confusing. IMO `show` shouldn't break just because we have numerical issues for _one_ of the computations.

This PR adds a `try`/`catch` around the problematic computations, so that `show` can still work even if some of the statistics fail to compute.