### PR TITLE
[Feature] Probability of Direction (pd)

### DIFF
--- a/src/MCMCChains.jl
+++ b/src/MCMCChains.jl
@@ -48,6 +48,7 @@ export rafterydiag
 export rstar
 
 export hpd
+export p_direction
 
 """
     Chains
@@ -85,5 +86,6 @@ include("modelstats.jl")
 include("plot.jl")
 include("tables.jl")
 include("rstar.jl")
+include("significance.jl")
 
 end # module

--- a/src/significance.jl
+++ b/src/significance.jl
@@ -1,0 +1,19 @@
+function p_direction(x::Vector{Float64})
+    return maximum([sum(x .> 0) ./ length(x), sum(x .< 0) ./ length(x)])
+end
+
+function p_direction(chains::Chains; kwargs...)
+    # Store everything.
+    funs = [p_direction]
+    func_names = [:p_direction]
+
+    # Summarize.
+    summary_df = summarize(
+        chains, funs...;
+        func_names=func_names,
+        name="Probability of Direction (pd)",
+        kwargs...
+    )
+
+    return summary_df
+end


### PR DESCRIPTION
Indices of effect significance/existence computed from posterior distributions are very common in some fields. This feature adds the [probability of direction](https://en.wikipedia.org/wiki/Probability_of_direction), `p_direction()`, a Bayesian [equivalent](https://easystats.github.io/bayestestR/articles/probability_of_direction.html#relationship-with-the-p-value) of the p-value. 

I followed the implementation of `mean()` by using the `summarize()` workflow.