### PR TITLE
Re-release 7.0.1 as 7.1.0 to follow semantic versioning

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
 keywords = ["markov chain monte carlo", "probablistic programming"]
 license = "MIT"
 desc = "Chain types and utility functions for MCMC simulations."
-version = "7.0.1"
+version = "7.1.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"


### PR DESCRIPTION
PR #316 introduced new functionality but incorrectly bumped the patch version. This re-releases it as 7.1.0 to follow semantic versioning.
